### PR TITLE
primary profile working

### DIFF
--- a/mfo/account/templates/account/profile_long.html
+++ b/mfo/account/templates/account/profile_long.html
@@ -17,8 +17,8 @@ https://mdbootstrap.com/docs/standard/extended/profiles/
                 <div class="card-header bg-secondary pt-3 pb-2 text-center">
                     <h1 class="text-white">{{ profile.name }}</h1>
                     <p class="text-light fs-5">
-                        {% for role in profile.users[0].roles %}
-                            <span class="mx-2">{{ role.name}}</span>
+                        {% for role in profile.roles %}
+                            <span class="mx-2">{{ role.name }}</span>
                         {% endfor %}
                     </p>
                 </div>

--- a/mfo/database/commands.py
+++ b/mfo/database/commands.py
@@ -10,6 +10,7 @@ import os
 from mfo.database.base import db
 from mfo.database.users import User
 from mfo.database.models import Profile
+import mfo.database.utilities
 
 
 bp = flask.Blueprint('database', __name__,)
@@ -52,13 +53,18 @@ def test_users():
                         password=hash_password(user_dict['password']),
                         roles=user_dict['roles'],
                     )
-            for profile in user_dict['profiles']:
-                profile['birthdate'] = datetime.strptime(profile['birthdate'], "%Y-%m-%d").date()
-                profile_entry=Profile(**profile)
-                user.profiles.append(profile_entry)
-
+            primary_profile = user_dict['primary_profile']
+            primary_profile['birthdate'] = datetime.strptime(primary_profile['birthdate'], "%Y-%m-%d").date()
+            profile_entry=Profile(**primary_profile)
+            user, profile_entry = mfo.database.utilities.set_primary_profile(user, profile_entry)
+            # add roles to profile
+            for role in user.roles:
+                profile_entry.roles.append(role)
             db.session.add(user)
+            db.session.add(profile_entry)
             print(f"Added userid: {user.email}")
+
+            
 
     db.session.commit()
     

--- a/mfo/database/models.py
+++ b/mfo/database/models.py
@@ -80,6 +80,8 @@ class Profile(db.Model):
     __tablename__ = 'profile'
     
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    #user_id: Mapped[int] = mapped_column(Integer, ForeignKey('user.id'), nullable=True)
+    primary: Mapped[bool] = mapped_column(default=False)
 
     client_id: Mapped[Optional[str]] = mapped_column(nullable=True)
     session: Mapped[Optional[str]] = mapped_column(nullable=True)

--- a/mfo/database/users.py
+++ b/mfo/database/users.py
@@ -1,9 +1,10 @@
 from flask_security.models import fsqla_v3 as fsqla
 from flask_security import SQLAlchemyUserDatastore
 from mfo.database.base import db
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, relationship, mapped_column
 
-from .models import profiles_users, profiles_roles
+from .models import Profile, profiles_users, profiles_roles
 
 fsqla.FsModels.set_db_info(db)
 
@@ -13,6 +14,9 @@ class Role(db.Model, fsqla.FsRoleMixin):
     )
 
 class User(db.Model, fsqla.FsUserMixin):
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    primary_profile_id: Mapped[int] = mapped_column(ForeignKey('profile.id'), nullable=True)
+    primary_profile: Mapped["Profile"] = relationship("Profile", uselist=False, foreign_keys=[primary_profile_id])
     profiles: Mapped[list["Profile"]] = relationship(
         secondary=profiles_users, back_populates="users"
     )

--- a/mfo/database/utilities.py
+++ b/mfo/database/utilities.py
@@ -1,15 +1,17 @@
 def find_primary_profile(user):
-    primary = None
-    for profile in user.profiles:
-        for u in profile.users:
-            if u.id == user.id:
-                primary = profile
-    return primary
+    return user.primary_profile
 
 def find_primary_user(profile):
-    primary = None
-    for user in profile.users:
-        for p in user.profiles:
-            if p.id == user.id:
-                primary = user
-    return primary
+    return profile.user if profile.primary else None
+
+def set_primary_profile(user, profile):
+    # Unset the current primary profile if it exists
+    if user.primary_profile:
+        user.primary_profile.primary = False
+    
+    # Set the new primary profile
+    profile.primary = True
+    user.primary_profile = profile
+    user.primary_profile_id = profile.id
+
+    return user, profile

--- a/tests/test_users.json
+++ b/tests/test_users.json
@@ -5,8 +5,7 @@
         "roles": [
             "Participant"
         ],
-        "profiles": [
-            {
+        "primary_profile": {
                 "client_id": null,
                 "session": null,
                 "name": "Brad Bigman",
@@ -21,8 +20,7 @@
                 "fees_paid": 0.0,
                 "comments": null,
                 "national_festival": true
-            }
-        ]
+        }
     },
     {
         "email": "admin@testmail.com",
@@ -31,8 +29,7 @@
             "Admin",
             "Participant"
         ],
-        "profiles": [
-            {
+        "primary_profile": {
                 "client_id": null,
                 "session": null,
                 "name": "Iamin Charge",
@@ -48,7 +45,6 @@
                 "fees_paid": 0.0,
                 "comments": null,
                 "national_festival": false
-            }
-        ]
+        }
     }
 ]


### PR DESCRIPTION
I mostly followed GitHub Copilot's proposed solution:

To better manage primary and secondary profiles while allowing users to manage multiple profiles and profiles to be associated with multiple users, I introduced a new attribute in the Profile model to explicitly mark a profile as the primary profile for a user. This approach avoids relying on matching IDs and provides a clear and unambiguous way to identify the primary profile.

Here's how I implemented this:

* Added a primary attribute to the Profile model:
  * This attribute is a boolean that indicates whether the profile is the primary profile for a user.
* Updated the relationship in the User model:
  * Added a new relationship to specifically handle the primary profile.
* Updated the utility functions:
  * Modified the functions to use the new primary attribute.

#### mfo.database.models.Profile

Added a primary attribute to the Profile model:

```
# from mfo/database/models.py

class Profile(db.Model):
    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
    user_id: Mapped[int] = mapped_column(Integer, ForeignKey('user.id'), nullable=True)
    primary: Mapped[bool] = mapped_column(default=False)
    
    # other fields...
    
    users: Mapped[List["User"]] = relationship(
        "User",
        secondary=profiles_users,
        back_populates="profiles"
    )
    
    # other fields and relationships...
```

#### mfo.database.users.User

Added a new relationship for the primary profile:

```
# from mfo/database/users.py

class User(db.Model, fsqla.FsUserMixin):
    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
    primary_profile_id: Mapped[int] = mapped_column(ForeignKey('profile.id'), nullable=True)
    primary_profile: Mapped["Profile"] = relationship("Profile", uselist=False, foreign_keys=[primary_profile_id])
    profiles: Mapped[List["Profile"]] = relationship(
        secondary=profiles_users, back_populates="users"
    )
```

#### mfo.database.utilities

Modify the utility functions to use the new primary attribute:

```
# from mfo/database/utilities.py

def find_primary_profile(user):
    return user.primary_profile

def find_primary_user(profile):
    return profile.user if profile.primary else None
```


When creating or updating profiles, ensured that only one profile is marked as primary for each user:

```
# Example function to set a primary profile for a user

def set_primary_profile(user, profile):
    # Unset the current primary profile if it exists
    if user.primary_profile:
        user.primary_profile.primary = False
    
    # Set the new primary profile
    profile.primary = True
    user.primary_profile = profile
    user.primary_profile_id = profile.id

    return user, profile
```

#### mfo.account.views.index()

Next, I changed the user account view function so it sets up a primary profile for new users, if they do not yet already have a primary profile:

```
# mfo/account/views.py

@bp.get('/')
@flask_security.auth_required()
def index():
    user = flask_security.current_user
    profile = mfo.database.utilities.find_primary_profile(user)
    if profile is None:
        profile = Profile()
        profile.id = user.id
        profile.email = user.email
        for role in user.roles:
            profile.roles.append(role)
        user, primary_profile = mfo.database.utilities.set_primary_profile(user, profile)
        db.session.add(primary_profile)
        db.session.commit()
    else:
        stmt = select(Profile).options(selectinload(Profile.roles)).filter_by(id=profile.id)
        profile = db.session.execute(stmt).scalar_one_or_none()
```

#### mfo.database.commands.test_users()

I changed the test_users CLI command so it also sets primary profiles for the users it creates.

```
@bp.cli.command('test_users')
@flask.cli.with_appcontext
def test_users():
    # ... code to check if user already exists and get users data from JSON file...

    for user_dict in users_list:
        if flask.current_app.security.datastore.find_user(email=user_dict['email']):
            print(f"userid {user_dict['email']} already exists. Skipping this user.")
        else:
            user = flask.current_app.security.datastore.create_user(
                        email=user_dict['email'],
                        password=hash_password(user_dict['password']),
                        roles=user_dict['roles'],
                    )
            primary_profile = user_dict['primary_profile']
            primary_profile['birthdate'] = datetime.strptime(primary_profile['birthdate'], "%Y-%m-%d").date()
            profile_entry=Profile(**primary_profile)
            user, profile_entry = mfo.database.utilities.set_primary_profile(user, profile_entry)
            # add roles to profile
            for role in user.roles:
                profile_entry.roles.append(role)
            db.session.add(user)
            db.session.add(profile_entry)
            print(f"Added userid: {user.email}")

    db.session.commit()
```

#### mfo/account/templates/profile_long.html

And, since I am no longer getting profile roles from the user entry (because primary role has roles added when user is created now), I can change the profile_long.html template so I get roles directly from the profile:

```
<!-- mfo/account/templates/profile_long.html -->

...

    <div class="card bg-white border border-secondary rounded h-100 ">
	<div class="card-header bg-secondary pt-3 pb-2 text-center">
	    <h1 class="text-white">{{ profile.name }}</h1>
	    <p class="text-light fs-5">
		{% for role in profile.roles %}
		    <span class="mx-2">{{ role.name }}</span>
		{% endfor %}
	    </p>
	</div>
	
...
```

#### mfo.home.views.new_user()

I also changed the *new_user()* view function in the *home* blueprint so it uses the *mfo.database.utilities.find_primary_profile()* function.

#### mfo.account.views

I also changed the *index()*, *edit_profile_post()*, and *edit_profile_get()* functions in the *account* blueprint so they use the *mfo.database.utilities.find_primary_profile()* function. Now, I can assume that every user always has a primary profile so I do not need to check if a profile already exists.

#### mfo/admin/views.delete_festival_data_post()

Changed *delete_festival_data_post()* view function in mfo/admin/views.py to clear *primary_profile_id* foreign key from user record before deleting profiles. Then I use the *mfo.database.utilities.find_primary_profile()* function to add back in a blank primary profile for each user.

### NOTES

This solution means that the user's primary profile will never be in the list returned from the "user.profiles" relationship. This means that "user.profiles" now gathers all "secondary" profiles and we can assume that the user's main profile is not in it. Maybe I should, create multiple types of "secondary" profiles, like "students", "children", and "groups"? That's for another issue, if needed.

But not the same for profile.users. Primary user will still be in the users list, along with other associated users. I think this will come in handy when identifying users who can manage a profile which includes the primary user.