### PR TITLE
fixed issue #36

### DIFF
--- a/mfo/account/forms/edit_profile.py
+++ b/mfo/account/forms/edit_profile.py
@@ -67,7 +67,8 @@ class ProfileEdit(FlaskForm):
             ('Teacher', 'Teacher'), 
             ('Guardian', 'Parent or Guardian'), 
             ('Accompanist', 'Accompanist'), 
-            ('Adjudicator', 'Adjudicator')
+            ('Adjudicator', 'Adjudicator'),
+            ('Admin', 'Admin'),
             ],
         default=['Participant'],
         option_widget=wtforms.widgets.CheckboxInput(),

--- a/mfo/account/templates/account/edit_profile.html
+++ b/mfo/account/templates/account/edit_profile.html
@@ -24,13 +24,18 @@
                     <label class="form-label">{{ form.rolenames.label }}</label>
                     <div class="row">
                         {% for subfield in form.rolenames %}
-                            <div class="col-md-4">
-                                <div class="form-check">
-                                    {{ subfield(class_="form-check-input") }}
-                                    {{ subfield.label(class_="form-check-label") }}
+                            {% if subfield.data != 'Admin' %}
+                                <div class="col-md-4">
+                                    <div class="form-check">
+                                        {{ subfield(class_="form-check-input") }}
+                                        {{ subfield.label(class_="form-check-label") }}
+                                    </div>
                                 </div>
-                            </div>
+                            {% endif %}
                         {% endfor %}
+                        {% if 'Admin' in form.rolenames.data %}
+                            <input type="hidden" name="rolenames" value="Admin" checked>
+                        {% endif %}
                     </div>
                 </div>
                 {% if form.rolenames.errors %}

--- a/mfo/account/views.py
+++ b/mfo/account/views.py
@@ -71,6 +71,11 @@ def edit_profile_post():
 
         # add new selected roles to profile   
         for selected_role in selected_role_names:
+            # Only allow Admin users to add Admin role
+            if selected_role == 'Admin' and 'Admin' not in user.roles:
+                print(f'#### ERROR!! User {user.email} tried to add Admin role')
+                continue
+            # Only a role if it is not already in the profile
             stmt = select(Role).where(Role.name==selected_role)
             role = db.session.execute(stmt).scalars().first()
             if role not in profile.roles:
@@ -83,7 +88,7 @@ def edit_profile_post():
         db.session.commit()
         return flask.redirect(flask.url_for('account.index'))
     
-    return flask.render_template('/account/index.html', profile=profile, form=form)
+    return flask.render_template('/account/edit_profile.html', form=form)
 
 
 @bp.get('/edit_profile')


### PR DESCRIPTION
## Roles not displayed correctly

First problem, where validation seems to not be working was caused bacause I was rendering the wrong template in the *edit_profile_pos()* view function. 

### mfo.account.views.edit_profile_post

I now render the */account/edit_profile.html* and the User profile edit works as expected.

## Allow Admin to uncheck all other roles

### mfo.account.forms.edit_profile

Added 'Admin' to the choices in the *rolenames* field. 

### mfo.account.views.edit_profile_post

Added a bit of logic to ensure that only Admin users can add an Admin role because I am worried someone might be able to manipulate a hidden field in the form.

### /account/templates/account/edit_profile.html

Added check to ensure only roled other than 'Admin' appear as checkboxes, then added hidden field for "Admin" checkbox so its value is used when validating the form.