### PR TITLE
Added HTMX to class reports

### DIFF
--- a/mfo/admin/templates/admin/class_report.html
+++ b/mfo/admin/templates/admin/class_report.html
@@ -7,60 +7,7 @@
 
 <div class="container pt-4">
     <h3>Classes</h3>
-    <table class="table">
-        <thead>
-            <tr>
-                <!-- The sort_by[:] and sort_order[:] ensure that a copy of the list is passed to avoid modifying the original list during URL generation. -->
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}">Class</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('name', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('name', sort_by[:], sort_order[:])) }}">Name</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('type', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('type', sort_by[:], sort_order[:])) }}">Type</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('discipline', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('discipline', sort_by[:], sort_order[:])) }}">Discipline</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('number_of_entries', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('number_of_entries', sort_by[:], sort_order[:])) }}">Entries</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('total_fees', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('total_fees', sort_by[:], sort_order[:])) }}">Total&nbsp;Fees</a>
-                </th>
-                <th>
-                    <a href="{{ url_for('admin.classes_get', 
-                    sort_by=update_sort('total_time', sort_by[:], sort_order[:]), 
-                    sort_order=update_order('total_time', sort_by[:], sort_order[:])) }}">Total&nbsp;Time</a>
-                </th>
-        </thead>
-        <tbody>
-            {% for _class in classes %}
-            <tr>
-                <td><a href="{{ url_for('admin.class_info_get', id=_class.id) }}">{{ _class.number_suffix }}</a></td>
-                <td>{{ _class.name }}</td>
-                <td>{{ _class.type }}</td>
-                <td>{{ _class.discipline }}</td>
-                <td class="text-end">{{ _class.number_of_entries }}</td>
-                <td class="text-end">{{ _class.total_fees }}</td>
-                <td class="text-end">{{ _class.total_time }}</td>
-            </tr>
-            
-            {% endfor %}
-        </tbody>
-    </table>
+
+    {% include "/admin/partials/class_table.html" %}
 
 {% endblock %}

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -1,0 +1,72 @@
+<!-- mfo/admin/templates/admin/partials/class_table.html -->
+
+<table class="table" id="class-table">
+    <thead>
+        <tr>
+            <!-- The sort_by[:] and sort_order[:] ensure that a copy of the list is passed to avoid 
+                 modifying the original list during URL generation. -->
+            <th hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
+                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Class</a>
+            </th>
+            <th hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('name', sort_by[:], sort_order[:]), 
+                sort_order=update_order('name', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Name</a>
+            </th>
+            <th hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('type', sort_by[:], sort_order[:]), 
+                sort_order=update_order('type', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Type</a>
+            </th>
+            <th hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('discipline', sort_by[:], sort_order[:]), 
+                sort_order=update_order('discipline', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Discipline</a>
+            </th>
+            <th class="text-end" hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('number_of_entries', sort_by[:], sort_order[:]), 
+                sort_order=update_order('number_of_entries', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Entries</a>
+            </th>
+            <th class="text-end" hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('total_fees', sort_by[:], sort_order[:]), 
+                sort_order=update_order('total_fees', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Total Fees</a>
+            </th>
+            <th class="text-end" hx-boost="true">
+                <a href="{{ url_for('admin.classes_get', 
+                sort_by=update_sort('total_time', sort_by[:], sort_order[:]), 
+                sort_order=update_order('total_time', sort_by[:], sort_order[:])) }}"
+                hx-target="#class-table"
+                hx-swap="outerHTML">Total Time</a>
+            </th>
+    </thead>
+    <tbody>
+        {% for _class in classes %}
+        <tr>
+            <td><a href="{{ url_for('admin.class_info_get', id=_class.id) }}">{{ _class.number_suffix }}</a></td>
+            <td>{{ _class.name }}</td>
+            <td>{{ _class.type }}</td>
+            <td>{{ _class.discipline }}</td>
+            <td class="text-end">{{ _class.number_of_entries }}</td>
+            <td class="text-end">{{ _class.total_fees }}</td>
+            <td class="text-end">{{ _class.total_time }}</td>
+        </tr>
+        
+        {% endfor %}
+    </tbody>
+</table>

--- a/mfo/admin/views.py
+++ b/mfo/admin/views.py
@@ -202,12 +202,22 @@ def classes_get():
     stmt = select(FestivalClass)
     _classes = db.session.execute(stmt).scalars().all()
     class_list = admin_services.get_class_list(_classes, sort_by, sort_order)
-    return flask.render_template(
-        'admin/class_report.html', 
-        classes=class_list, 
-        sort_by=sort_by, 
-        sort_order=sort_order
+    if flask.request.headers.get('HX-Request'):
+        # Render a different template for HTMX requests
+        return flask.render_template(
+            'admin/partials/class_table.html', 
+            classes=class_list, 
+            sort_by=sort_by, 
+            sort_order=sort_order
         )
+    else:
+        return flask.render_template(
+            'admin/class_report.html', 
+            classes=class_list, 
+            sort_by=sort_by, 
+            sort_order=sort_order
+            )
+
 
 
 @bp.get('/info/class')


### PR DESCRIPTION
I modified the Class Report page and view function to use [HTMX](https://htmx.org/) when sorting the table

## Add HTMX to Flask page

### Add HTMX Javascript Library

[Add HTMX Javascript library](https://htmx.org/docs/#installing) to the project's base template, between the `<head>` tags:

```
<!-- mfo/templates/base.html -->

...
    <script src="https://unpkg.com/htmx.org@2.0.0" integrity="sha384-wS5l5IKJBvK6sPTKa2WZ1js3d947pvWXbPJ1OmWfEuxLgeHcEbjUUA5i9V5ZkpCw" crossorigin="anonymous"></script>
...
```

### Create partial template

Then, take table code from the report templates and copy it to a new file in the partials folder. For example, take the following text from *mfo/admin/templates/admin/class_report.html* and place it in  *mfo/admin/templates/admin/partials/class_table.html*:

```
<!-- mfo/admin/templates/admin/partials/class_table.html -->

<table class="table">
    <thead>
        <tr>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}">Class</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('name', sort_by[:], sort_order[:]), 
                sort_order=update_order('name', sort_by[:], sort_order[:])) }}">Name</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('type', sort_by[:], sort_order[:]), 
                sort_order=update_order('type', sort_by[:], sort_order[:])) }}">Type</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('discipline', sort_by[:], sort_order[:]), 
                sort_order=update_order('discipline', sort_by[:], sort_order[:])) }}">Discipline</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('number_of_entries', sort_by[:], sort_order[:]), 
                sort_order=update_order('number_of_entries', sort_by[:], sort_order[:])) }}">Entries</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('total_fees', sort_by[:], sort_order[:]), 
                sort_order=update_order('total_fees', sort_by[:], sort_order[:])) }}">Total&nbsp;Fees</a>
            </th>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('total_time', sort_by[:], sort_order[:]), 
                sort_order=update_order('total_time', sort_by[:], sort_order[:])) }}">Total&nbsp;Time</a>
            </th>
    </thead>
    <tbody>
        {% for _class in classes %}
        <tr>
            <td><a href="{{ url_for('admin.class_info_get', id=_class.id) }}">{{ _class.number_suffix }}</a></td>
            <td>{{ _class.name }}</td>
            <td>{{ _class.type }}</td>
            <td>{{ _class.discipline }}</td>
            <td class="text-end">{{ _class.number_of_entries }}</td>
            <td class="text-end">{{ _class.total_fees }}</td>
            <td class="text-end">{{ _class.total_time }}</td>
        </tr>
        
        {% endfor %}
    </tbody>
</table>
```

The add an *include* Jinja2 statement to bring the table into the *class_report.html* template. The entire *class_report.html* template is now:

```
<!-- admin/templates/admin/class_report.html -->

{% extends "/admin/_reports_base.html" %}
{% block title %}Classes{% endblock %}

{% block report_content %}

    <div class="container pt-4">
        <h3>Classes</h3>
    
        {% include "/admin/partials/class_table.html" %}

{% endblock %}
```

Run the program and see that everything works the same.


## Add HTMX attributes to HTML code


Now, make one of the table headers send and hx-get instead of a normal GET request and re-render the table instead of the entire page. The original header is:

```
<table class="table" id="class_table">
  <thead>
    <tr>
      <th>
        <a href="{{ url_for('admin.classes_get', 
        sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
        sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}">Class</a>
      </th>
```

Add `id="class_table"` to the table tag, so HTMX will have a target to swap out. In each table header, Add `hx-get` so clicking on the link sends an HTMX get request, and add HTMX classes to control how the swap happens. The final table header code will look like:

```
<table class="table" id="class-table">
    <thead>
        <tr>
            <th>
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
                hx-get="{{ url_for('admin.classes_get', 
                sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
                hx-target="#class-table"
                hx-swap="outerHTML">
                  Class
              </a>
          </th>
```

Alternatively, to make the template a bit cleaner, use the [*hx-boost* attribute](https://htmx.org/docs/#boosting) to automatically convert anchors in child elements to HTMX-powered anchors, as shown below. Note that you still need to specify other HTMX attributes such as target and swap type in the anchor:

```
            <th hx-boost="true">
                <a href="{{ url_for('admin.classes_get', 
                sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
                hx-target="#class-table"
                hx-swap="outerHTML">Class</a>
            </th>
```

## Update view function to render partial template

Since the *class_get()* view function now neads to render the full page tempalte on a normal request and only the table template on an HX-GET request, test what kind of request it is receiving (or create a separate view function for the HTMX table request).
Add `if flask.request.headers.get('HX-Request'):` to the function as shown below:

```
@bp.get('/report/classes')
@flask_security.auth_required()
@flask_security.roles_required('Admin')
def classes_get():
    sort_by = flask.request.args.getlist('sort_by')
    sort_order = flask.request.args.getlist('sort_order')

    stmt = select(FestivalClass)
    _classes = db.session.execute(stmt).scalars().all()
    class_list = admin_services.get_class_list(_classes, sort_by, sort_order)
    
    if flask.request.headers.get('HX-Request'):
        # Render a different template for HTMX requests
        return flask.render_template(
            'admin/partials/class_table.html', 
            classes=class_list, 
            sort_by=sort_by, 
            sort_order=sort_order
        )
    else:
        return flask.render_template(
            'admin/class_report.html', 
            classes=class_list, 
            sort_by=sort_by, 
            sort_order=sort_order
            )
```

Now you can check that HTMX is being used by using the developer tools in your browser. For example, in Firefox, press the *F12* key to open the tools then select the *Network* tool. When the page is rendered for the first time you will see the HTML document, CSS, javascript, and other elements are sent to the browser from the server. But, when you sort using a header that has HTMX enabled, you only get a single HTMX request. If you search using a header that does not yet have HTMX enabled, you can see the entire document plus CSS and javascript is loaded again.