### PR TITLE
removed htmx

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -1,9 +1,10 @@
 from flask_wtf import FlaskForm
-from wtforms import FileField, StringField, SubmitField, HiddenField, IntegerField, SelectField, TextAreaField, PasswordField
+from flask_wtf.file import FileField, FileRequired
+from wtforms import StringField, SubmitField, HiddenField, IntegerField, SelectField, TextAreaField, PasswordField
 from wtforms.validators import DataRequired, InputRequired, Length, Optional
 
 class UploadForm(FlaskForm):
-    file = FileField('Spreadsheet File', [InputRequired()])
+    file = FileField('Spreadsheet File', [FileRequired()])
     submit = SubmitField('Upload')
 
 class ConfirmForm(FlaskForm):

--- a/mfo/admin/templates/admin/index.html
+++ b/mfo/admin/templates/admin/index.html
@@ -10,7 +10,7 @@
 <div class="container pt-4">
     <div id="file-form">
         <h3>Upload Spreadsheet</h3>
-        <form hx-post="{{ url_for('admin.index_post') }}" hx-swap="innerHTML" hx-target="#file-form" enctype="multipart/form-data">
+        <form method="POST" action="{{ url_for('admin.index_post') }}" enctype="multipart/form-data">
             {{ form.hidden_tag() }}
             <div class="mb-3">
                 {{ form.file(class="form-control") }}

--- a/mfo/admin/templates/admin/list_issues.html
+++ b/mfo/admin/templates/admin/list_issues.html
@@ -1,54 +1,28 @@
+<!-- admin/templates/admin/index.html -->
+
+{% extends "/admin/_admin_base.html" %}
+{% block title %}Spreadsheet upload{% endblock %}
+
+{% block admin_content %}
+
+{% include "flash.html" %}
+
 <div class="container pt-4 pb-10">
     <!-- {% include "flash.html" %} -->
     
-    <div class="container">
-        <div class="row">
-            <div class="col">
-                <h3>Review Issues</h3>
-            </div>
-        </div>
-    </div>
-
     {% if issues %}
-
-    <div class="container">
-        <div class="row pb-3">
-            <div class="col-sm-9 pb-3 pb-md-0 align-middle"> 
-                Review the issues list, below, and resolve issues in the spreadsheet data. 
-                Scroll to the end and click <i>Cancel</i> to discard the uploaded changes.
-            </div>
-            <div class="col-sm-3 text-center text-md-end align-middle">
-                <button type="button" class="btn btn-primary pt-2" data-bs-toggle="modal" data-bs-target="#filenameModal">Save Issues List</button>
-        </div>
-    </div>
-
-    <div class="table-responsive">
-        <table class="table table-bordered table-striped table-hover">
-            <thead class="table-dark">
-                <tr>
-                    <th>Issue</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for issue in issues %}
-                <tr> 
-                    <td>{{ issue }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
+        {% include "admin/partials/issues.html" %}
     {% else %}
-    <div class="alert alert-success" role="alert">
-        No issues found. Ready to commit.
-    </div>
+        <div class="alert alert-success" role="alert">
+            No issues found. Ready to commit.
+        </div>
     {% endif %}
 
     {% include "admin/partials/confirm_form.html" %}
     
 </div>
 
-<!-- Modal -->
+<!-- Modal for saving issues file -->
 <div class="modal fade" id="filenameModal" tabindex="-1" aria-labelledby="filenameModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -56,7 +30,7 @@
                 <h5 class="modal-title" id="filenameModalLabel">Enter Filename</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form hx-post="{{ url_for('admin.generate_text_file') }}" hx-swap="none" hx-trigger="submit" id="filenameForm">
+            <form action="{{ url_for('admin.generate_text_file') }}" method="post" id="filenameForm">
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="filename">Filename</label>
@@ -73,7 +47,7 @@
 </div>
 
 
-<!-- Needed for file download.
+<!-- Needed for issues file download.
 This script checks the response for a redirect URL and navigates to it, triggering the file download. -->
 {% block additional_js %}
 <script>
@@ -86,4 +60,7 @@ This script checks the response for a redirect URL and navigates to it, triggeri
         }
     });
 </script>
+
+{% endblock %}
+
 {% endblock %}

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -5,54 +5,40 @@
         <tr>
             <!-- The sort_by[:] and sort_order[:] ensure that a copy of the list is passed to avoid 
                  modifying the original list during URL generation. -->
-            <th hx-boost="true">
+            <th>
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
-                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Class</a>
+                sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}">Class</a>
             </th>
-            <th hx-boost="true">
+            <th>
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('name', sort_by[:], sort_order[:]), 
-                sort_order=update_order('name', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Name</a>
+                sort_order=update_order('name', sort_by[:], sort_order[:])) }}">Name</a>
             </th>
-            <th hx-boost="true">
+            <th>
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('type', sort_by[:], sort_order[:]), 
-                sort_order=update_order('type', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Type</a>
+                sort_order=update_order('type', sort_by[:], sort_order[:])) }}">Type</a>
             </th>
-            <th hx-boost="true">
+            <th>
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('discipline', sort_by[:], sort_order[:]), 
-                sort_order=update_order('discipline', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Discipline</a>
+                sort_order=update_order('discipline', sort_by[:], sort_order[:])) }}">Discipline</a>
             </th>
-            <th class="text-end" hx-boost="true">
+            <th class="text-end">
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('number_of_entries', sort_by[:], sort_order[:]), 
-                sort_order=update_order('number_of_entries', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Entries</a>
+                sort_order=update_order('number_of_entries', sort_by[:], sort_order[:])) }}">Entries</a>
             </th>
-            <th class="text-end" hx-boost="true">
+            <th class="text-end">
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('total_fees', sort_by[:], sort_order[:]), 
-                sort_order=update_order('total_fees', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Total Fees</a>
+                sort_order=update_order('total_fees', sort_by[:], sort_order[:])) }}">Total Fees</a>
             </th>
-            <th class="text-end" hx-boost="true">
+            <th class="text-end">
                 <a href="{{ url_for('admin.classes_get', 
                 sort_by=update_sort('total_time', sort_by[:], sort_order[:]), 
-                sort_order=update_order('total_time', sort_by[:], sort_order[:])) }}"
-                hx-target="#class-table"
-                hx-swap="outerHTML">Total Time</a>
+                sort_order=update_order('total_time', sort_by[:], sort_order[:])) }}">Total Time</a>
             </th>
     </thead>
     <tbody>

--- a/mfo/admin/templates/admin/partials/issues.html
+++ b/mfo/admin/templates/admin/partials/issues.html
@@ -1,0 +1,35 @@
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h3>Review Issues</h3>
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="row pb-3">
+        <div class="col-sm-9 pb-3 pb-md-0 align-middle"> 
+            Review the issues list, below, and resolve issues in the spreadsheet data. 
+            Scroll to the end and click <i>Cancel</i> to discard the changes.
+        </div>
+        <div class="col-sm-3 text-center text-md-end align-middle">
+            <button type="button" class="btn btn-primary pt-2" data-bs-toggle="modal" data-bs-target="#filenameModal">Save Issues List</button>
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-bordered table-striped table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>Issue</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for issue in issues %}
+            <tr> 
+                <td>{{ issue }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
Removing HTMX simplifies some of the code (where HTMX is not really needed).

Fixes #45. Closes #42 and #39.

### The *partials/class_table.html* template

In the Class Report table template, *mfo/admin/templates/admin/partials/class_table.html*, I used HTMX to replace the table in the page with a sorted table when each link is clicked. 

Each table header, like the one shown below:

```
<th hx-boost="true">
    <a href="{{ url_for('admin.classes_get', 
    sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
    sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}"
    hx-target="#class-table"
    hx-swap="outerHTML">Class</a>
</th>
```

Is simplified to:

```
<th>
    <a href="{{ url_for('admin.classes_get', 
    sort_by=update_sort('number_suffix', sort_by[:], sort_order[:]), 
    sort_order=update_order('number_suffix', sort_by[:], sort_order[:])) }}">Class</a>
</th>
```

### The *classes_get()* view function

And, in the *classes_get()* view function in *mfo/admin/views.py*, the logic that checks if the request came in as an HTMX request or not is much simplified:

```
if flask.request.headers.get('HX-Request'):
    # Render a different template for HTMX requests
    return flask.render_template(
        'admin/partials/class_table.html', 
        classes=class_list, 
        sort_by=sort_by, 
        sort_order=sort_order
    )
else:
    return flask.render_template(
        'admin/class_report.html', 
        classes=class_list, 
        sort_by=sort_by, 
        sort_order=sort_order
        )
```

Is simplified to:

```
return flask.render_template(
    'admin/class_report.html', 
    classes=class_list, 
    sort_by=sort_by, 
    sort_order=sort_order
    )
```

### The *index_post()* view function

In the admin blueprint's index, I no longer have to create a special HTMX request with the HX-Redirect header to reload the full page and avoid the page-within-a-page effect caused when the full page is swapped into the area where HTMX wants to place its partial HTML content.

So, the redirect in the *index_post()* view function in *mfo/admin/views.py*:

```
if not succeeded:
    flask.flash(message, 'danger')
    response = flask.jsonify("")
    response.headers['HX-Redirect'] = flask.url_for('admin.upload_fail_get')
    return response
```

Is simplified to:

```
if not succeeded:
    flask.flash(message, 'danger')
    return flask.redirect(flask.url_for('admin.upload_fail_get'))
```


### The *list_issues.html* template

I also replaced the *mfo/admin/templates/admin/partials/list_issues.html* template with a full template, *mfo/admin/templates/admin/list_issues.html* that included the base template, etc. 

Then, in the *confirm_get()* view function, I updated the parameters in the *render_template* method from:

```
return flask.render_template('admin/partials/list_issues.html', issues=issues, form=form)
```

to:

```
return flask.render_template('admin/list_issues.html', issues=issues, form=form)
```