### PR TITLE
Added syllabus file download page

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -3,7 +3,11 @@ from flask_wtf.file import FileField, FileRequired
 from wtforms import StringField, SubmitField, HiddenField, IntegerField, SelectField, TextAreaField, PasswordField
 from wtforms.validators import DataRequired, InputRequired, Length, Optional
 
-class UploadForm(FlaskForm):
+class UploadSyllabusForm(FlaskForm):
+    file = FileField('Upload Syllabus File', [FileRequired()])
+    submit = SubmitField('Upload')
+
+class UploadRegistrationsForm(FlaskForm):
     file = FileField('Upload Registrations File', [FileRequired()])
     submit = SubmitField('Upload')
 

--- a/mfo/admin/services/syllabus.py
+++ b/mfo/admin/services/syllabus.py
@@ -1,0 +1,125 @@
+import pandas as pd
+import flask
+import tabula
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+import io
+
+from mfo.database.base import db
+from mfo.database.models import FestivalClass
+import mfo.utilities
+
+
+def verify_pdf(tables):
+    """Verify that the tables extracted from the PDF file are in the expected format."""
+
+    if not tables:
+        flask.flash("No tables found in the PDF file. Database not updated.", "danger")
+        print("PDF NO TABLES")
+        return False
+    
+    for table in tables:
+        if table.shape[1] != 4:
+            flask.flash("PDF file table has wrong number of columns. Database not updated.", "danger")
+            return False
+        
+    reference_columns = ['Unnamed: 0', 'Unnamed: 1', 'Class Based', 'Unnamed: 2']
+    first_row_reference = ['Class Sec #','Description']
+
+    if not all(table.columns == reference_columns):
+        flask.flash("Wrong column headers in PDF file. Database not updated.", "danger")
+        return False
+    
+    if not all(table.iloc[0, :2] == first_row_reference):
+        flask.flash("Wrong column headers in PDF file. Database not updated.", "danger")
+        return False
+
+    return True
+    
+
+
+
+def to_table(pdf_file):
+    """Convert the pdf file to a pandas dataframe."""
+
+    tables = tabula.read_pdf(
+            pdf_file,
+            pages='all', 
+            multiple_tables=True, 
+            stream=True, 
+            silent=True, 
+            guess=True
+            )
+    
+    if not verify_pdf(tables):
+        return False, None
+
+    combined_df = pd.DataFrame()
+
+    for table in tables:
+        
+        # Drop the first 3 rows and reset the index
+        df = table.drop(table.index[:2])  
+        
+        df.columns = ["number","description", "fee", "festival"]
+        df["suffix"] = pd.Series(dtype="string")
+        
+        df.suffix = df.number.str[4:]
+        df.number = df.number.str[0:4]
+        
+        df = df[["number", "suffix", "description", "fee"]]
+        
+        combined_df = pd.concat([combined_df, df], ignore_index=True)
+
+        # Special case for the last page of the syllabus, drop rows where fee = "n/a"
+        combined_df = combined_df[combined_df.fee != "n/a"]
+
+    return True, combined_df
+
+
+def load_database(combined_df):
+    """
+    Load the syllabus data into the database. Note that I do not 
+    generate a list of issues here. I should probably do that.
+    """
+    # issues = mfo.utilities.CustomList()
+
+    try:
+        for index, row in combined_df.iterrows():
+
+            # In dataframes converted from PDF, empty strings are not None, so we need to convert them
+            if row.suffix == "":
+                suffix = None
+            else:
+                suffix = row.suffix
+
+            stmt = sa.select(FestivalClass).where(
+                FestivalClass.number == row.number,
+                FestivalClass.suffix == suffix,
+            )
+            festival_class = db.session.execute(stmt).scalar_one_or_none()
+
+            if festival_class is None:
+                festival_class = FestivalClass(number=row.number, suffix=suffix, name=row.description, fee=row.fee)
+                db.session.add(festival_class)
+            else:
+                if festival_class.name == None:
+                    # issues.append(f"**** Class {row['number']}{row['suffix']}: added description and fee from Syllabus")
+                    festival_class.name = row.description
+                    festival_class.fee = row.fee
+                    db.session.add(festival_class)
+
+        flask.flash("Syllabus added to database.", "success")
+        db.session.commit()
+        
+    except Exception as e:
+        db.session.rollback()
+        flask.flash(f"Error adding Syllabus to database: {e}. Database not updated.", "danger")
+        # issues.append(f"**** Error adding Syllabus to database: {e}")
+
+
+def add_to_db(pdf_file):
+    """Add the contents of the pdf file to the database."""
+    succeeded, combined_df = to_table(pdf_file)
+    if succeeded:
+        load_database(combined_df)

--- a/mfo/admin/templates/admin/upload_syllabus.html
+++ b/mfo/admin/templates/admin/upload_syllabus.html
@@ -1,4 +1,4 @@
-<!-- admin/templates/admin/upload_registrations.html -->
+<!-- admin/templates/admin/upload_syllabus.html -->
 
 {% extends "/admin/_admin_base.html" %}
 {% block title %}File upload{% endblock %}
@@ -10,7 +10,7 @@
 <div class="container pt-4">
     <div id="file-form">
         {{ form.file.label(class="form-label h4") }}
-        <form method="POST" action="{{ url_for('admin.upload_registrations_post') }}" enctype="multipart/form-data">
+        <form method="POST" action="{{ url_for('admin.upload_syllabus_post') }}" enctype="multipart/form-data">
             {{ form.hidden_tag() }}
             {{ form.file(class="form-control mb-3") }}
             {{ form.submit(class="btn btn-primary mb-3") }}

--- a/mfo/templates/navbar_admin.html
+++ b/mfo/templates/navbar_admin.html
@@ -2,6 +2,7 @@
 <div class="dropdown">
     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown">Admin</a>
     <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="{{ url_for('admin.upload_syllabus_get') }}">Upload Syllabus</a></li>
         <li><a class="dropdown-item" href="{{ url_for('admin.upload_registrations_get') }}">Upload Registrations</a></li>
         <li><a class="dropdown-item" href="{{ url_for('admin.delete_festival_data_get') }}">Delete Festival Data</a></li>
     </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas
 odfpy
 openpyxl
 Flask-Session[cachelib]
+tabula-py[jpype]


### PR DESCRIPTION
Closes #44 

## Import Syllabus File

### Admin Navbar

Added a drop-down menu in the *Admin* dropdown navbar in the *mfo/templates/navbar_admin.html* template:

```html
<li><a class="dropdown-item" href="{{ url_for('admin.upload_syllabus_get') }}">Upload Syllabus</a></li>
```

### Forms

I renamed the *UploadForm()* class in *mfo/admin/forms.py* to *UploadRegistrationsForm()*, and created a new class named *UploadSyllabusForm()*. I know I could have "generalized" the *UploadForm()* class in *mfo/admin/forms.py* by making the label a variable that is passed to the class's constructor, but I am anticipating that, in the future, the syllabus and registrations upload forms might need different fields.

The new *UploadSyllabusForm()* is shown below:

```python
class UploadSyllabusForm(FlaskForm):
    file = FileField('Upload Syllabus File', [FileRequired()])
    submit = SubmitField('Upload')
```

And, I need to find the instances where the *UploadForm()* class is instantiated and rename it to *UploadRegistrationsForm()*. I changed the form name in the following view functions in *mfo/admin/views.py*:

* *upload_registrations_get()*
* *upload_registrations_post()*

### View functions

I created two new view functions in *mfo/admin/views.pdf* to display the Syllabus upload page and to handle the input from the form.

#### Import helper module 

The *syllabus_pdf* module will provide the functions that process the Syllabus PDF and load its contents into the database:

```python
import mfo.admin.services.syllabus_pdf as syllabus_pdf
```

#### *upload_syllabus_get()*

Simply display the Syllabus upload page with the form

```python
@bp.get('/upload_syllabus')
@flask_security.auth_required()
@flask_security.roles_required('Admin')
def upload_syllabus_get():
    form = mfo.admin.forms.UploadSyllabusForm()
    return flask.render_template('admin/upload_syllabus.html', form=form)
```

#### *upload_syllabus_post()*

Handle the input from the form. I process the data using the *mfo/admin/services/syllabus.py* module, which I create later.

```python
@bp.post('/upload_syllabus')
@flask_security.auth_required()
@flask_security.roles_required('Admin')
def upload_syllabus_post():
    form = mfo.admin.forms.UploadSyllabusForm()
    if form.validate_on_submit():
        file = form.file.data
        if file.filename.endswith('.pdf'):
            syllabus.add_to_db(file)
            return flask.redirect(flask.url_for('admin.upload_syllabus_get')) 
        else:
            flask.flash(
                f"Uploaded file is not a PDF file." +
                f"Please select the Syllabus PDF file",
                'danger'
                )
            return flask.redirect(flask.url_for('admin.upload_syllabus_get'))
```

### *admin/upload_syllabus.html* Template

Create a template to present the file upload page. This is the same as the *upload_registrations.html* template with just the action URL changed.

```html
<!-- admin/templates/admin/upload_syllabus.html -->

{% extends "/admin/_admin_base.html" %}
{% block title %}File upload{% endblock %}

{% block admin_content %}

{% include "flash.html" %}

<div class="container pt-4">
    <div id="file-form">
        {{ form.file.label(class="form-label h4") }}
        <form method="POST" action="{{ url_for('admin.upload_syllabus_post') }}" enctype="multipart/form-data">
            {{ form.hidden_tag() }}
            {{ form.file(class="form-control mb-3") }}
            {{ form.submit(class="btn btn-primary mb-3") }}
        </form>
    </div>
</div>

{% endblock %}
```

#### What I learned

The *placeholder* attribute is not supported for [*<input type="file">* elements](https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)) in HTML. The placeholder attribute is typically used with text input fields, such as *<input type="text">*, *<textarea>*, etc. That's why I am using labels on this page.


### *mfo/admin/services/syllabus.py*

The Syllabus is a PDF file that contains one large table, split across many pages. The table has four columns: class number and suffix, description, fee, and festival type.

I evaluated two Python libraries for reading tables from PDFs: *camelot* and *tabula-py*
The *camelot* libray will not read from a file-like object and can only read PDF files from disk. So, I used the *tabula-py* library.

Tabula required the Java runtime, so install it using *apt*:

```
(.venv) $ sudo apt install default-jre
```

Then add `tabula-py[jpype]` to the *requirements.txt* file and install it in the Python virtual environment:

```
(.venv) $ pip install -r requirements.txt
```

Finally, I create the *mfo/admin/services/syllabus.py* module with the following functions:

* verify_pdf(tables)
  * Verify that the tables extracted from the PDF file are in the expected format.
* to_table(pdf_file)
  * Convert the pdf file to a pandas dataframe
* load_database(combined_df)
  * Load the syllabus data into the database.
* add_to_db(pdf_file)
  * Uses the above three functions to add teh Syllabus table in the Syllabus PDF file to the database

#### What I learned

Because I used the pandas dataframe *iterrrows()* method to iterate over the rows, I can't use `row.name` to read or update the *name* column in the dataframe, and instead need to use `row['name']`. This is because, in each row object returned by *itterows()*, `row.name` refers to the index number of the row in the DataFrame, not a column named "name". The solution is to use either `row['name']` to identify the contents of the *name* column or label column with something like "description" instead of "name". I chose the latter approach.

#### No issues list

I did not generate a list of issues from processing the PDF file and adding it to the database, like I did when processing the registrations file. I should probably do that at some point in the future. However, I can't think of a way to avoid a bunch of noise about "duplicate class numbers" because I expect to find many existing classes if the Syllabus file is added after the registrations file.
