### PR TITLE
times displayed as minutes and seconds

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -3,6 +3,32 @@ from flask_wtf.file import FileField, FileRequired
 from wtforms import StringField, SubmitField, HiddenField, IntegerField, SelectField, TextAreaField, PasswordField
 from wtforms.validators import DataRequired, InputRequired, Length, Optional
 
+class_types = [
+        ('', 'None'),
+        ('Solo', 'Solo'),
+        ('Duet', 'Duet'),
+        ('Trio', 'Trio'),
+        ('Quartet', 'Quartet'),
+        ('Quintet', 'Quintet'),
+        ('Recital', 'Recital'),
+        ('Ensemble', 'Ensemble'),
+    ]
+
+disciplines = [
+        ('', 'None'),
+        ('Vocal', 'Vocal'),
+        ('Piano', 'Piano'),
+        ('Organ', 'Organ'),
+        ('Strings', 'Strings'),
+        ('Recorder', 'Recorder'),
+        ('Woodwinds', 'Woodwinds'),
+        ('Brass', 'Brass'),
+        ('Percussion', 'Percussion'),
+        ('Instrumental', 'Instrumental'),
+        ('Musical Theatre', 'Musical Theatre'),
+    ]
+
+
 class UploadSyllabusForm(FlaskForm):
     file = FileField('Upload Syllabus File', [FileRequired()])
     submit = SubmitField('Upload')
@@ -18,57 +44,30 @@ class ConfirmForm(FlaskForm):
 class EditClassBasicInfoForm(FlaskForm):
     number = StringField('Number', validators=[DataRequired(), Length(max=10)])
     suffix = StringField('Suffix', validators=[Optional(), Length(max=5)])
-    class_type_choices = [
-        ('', 'None'),
-        ('Solo', 'Solo'),
-        ('Duet', 'Duet'),
-        ('Trio', 'Trio'),
-        ('Quartet', 'Quartet'),
-        ('Quintet', 'Quintet'),
-        ('Recital', 'Recital'),
-        ('Ensemble', 'Ensemble'),
-    ]
+    class_type_choices = class_types
     class_type = SelectField('Class Type', choices=class_type_choices, validators=[Optional()])
     name = StringField('Name', validators=[Optional(), Length(max=60)])
-    discipline_choices = [
-        ('', 'None'),
-        ('Strings', 'Strings'),
-        ('Piano', 'Piano'),
-        ('Voice', 'Voice'),
-        ('Winds', 'Winds'),
-    ]
+    discipline_choices = disciplines
     discipline = SelectField('Discipline', choices=discipline_choices, validators=[Optional()])
     fee = IntegerField('Fee', validators=[DataRequired()])
-    adjudication_time = IntegerField('Adjudication Time', validators=[Optional()])
-    move_time = IntegerField('Move Time', validators=[Optional()])
+    adjudication_mins = IntegerField('Adjudication Minutes', validators=[InputRequired()])
+    adjudication_secs = IntegerField('Adjudication Seconds', validators=[InputRequired()])
+    move_mins = IntegerField('Move Minutes', validators=[InputRequired()])
+    move_secs = IntegerField('Move Seconds', validators=[InputRequired()])
     submit = SubmitField('Update')
     
 class EditRepertoireForm(FlaskForm):
     id = HiddenField('ID')
     title = StringField('Title', validators=[DataRequired(), Length(max=60)])
     composer = StringField('Composer', validators=[DataRequired(), Length(max=60)])
-    discipline_choices = [
-        ('', 'None'),
-        ('Strings', 'Strings'),
-        ('Piano', 'Piano'),
-        ('Voice', 'Voice'),
-        ('Winds', 'Winds'),
-    ]
+    discipline_choices = disciplines
     discipline = SelectField('Discipline', choices=discipline_choices, validators=[Optional()])
-    type_choices = [
-        ('', 'None'),
-        ('Solo', 'Solo'),
-        ('Duet', 'Duet'),
-        ('Trio', 'Trio'),
-        ('Quartet', 'Quartet'),
-        ('Quintet', 'Quintet'),
-        ('Recital', 'Recital'),
-        ('Ensemble', 'Ensemble'),
-    ]
+    type_choices = class_types
     type = SelectField('Type', choices=type_choices, validators=[Optional()])
     level = StringField('Level', validators=[Optional(), Length(max=60)])
-    duration = IntegerField('Duration', validators=[DataRequired()])
-    description = TextAreaField('Description', validators=[Optional()], render_kw={"rows": 10, "placeholder": "Enter description here..."})
+    duration_mins = IntegerField('Minutes', validators=[InputRequired()])
+    duration_secs = IntegerField('Seconds', validators=[InputRequired()])
+    description = TextAreaField('Description', validators=[Optional()], render_kw={"rows": 5, "placeholder": "Enter description here..."})
     submit = SubmitField('Update')
 
 

--- a/mfo/admin/static/css/styles.css
+++ b/mfo/admin/static/css/styles.css
@@ -5,3 +5,7 @@
     width: 4em; /* Adjust based on testing */
 }
 
+
+.time-width {
+    width: 100px; 
+}

--- a/mfo/admin/templates/admin/class_edit_info.html
+++ b/mfo/admin/templates/admin/class_edit_info.html
@@ -21,55 +21,57 @@
         {{ form.hidden_tag() }}
         <div class="card-body">
             <div class="row">
-                <div class="col-xl-2 col-sm-4 col-md-3 col-12 mt-sm-0 mt-0">
+                <div class="col-xl-2 col-lg-3 col-sm-6 col-12 mt-sm-0 mt-0">
                     <div class="form-group d-flex align-items-center">
                         <label for="numberField" class="me-2"><strong>Number:</strong></label>
                         {{ form.number(id="numberField", class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-2 col-sm-3 col-12 mt-sm-0 mt-2">
+                <div class="col-xl-2 col-lg-3 col-sm-6 col-12 mt-sm-0 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="suffix" class="me-2"><strong>Suffix:</strong></label>
                         {{ form.suffix(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-8 col-12 mt-2 mt-xl-0">
+                <div class="col-xl-8 col-lg-6 col-12 mt-2 mt-xl-0">
                     <div class="form-group d-flex align-items-center">
                         <label for="name" class="me-2"><strong>Name:</strong></label>
                         {{ form.name(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-2 col-md-4 col-sm-6 col-12 mt-2">
+                <div class="col-lg-4 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="class_type" class="me-2"><strong>Type:</strong></label>
                         {{ form.class_type(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-2 col-md-4 col-sm-6 col-12 mt-2">
+                <div class="col-lg-4 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="discipline" class="me-2"><strong>Discipline:</strong></label>
                         {{ form.discipline(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-2 col-md-4 col-sm-6 col-12 mt-2">
+                <div class="col-lg-4 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="fee" class="me-2"><strong>Fee:</strong></label>
                         {{ form.fee(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-xl-2 col-md-4 col-sm-6 col-12 d-none d-sm-block d-md-none">
+                <div class="col-12 d-none d-md-block d-xl-none">
                     <!-- spacer -->
                 </div>
-                <div class="col-xl-3 col-md-6 col-sm-6 col-12 mt-2">
+                <div class="col-xl-6 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center">
-                        <label for="adjudication_time" class="me-2"><strong>Adjudication Time:</strong></label>
-                        {{ form.adjudication_time(class="form-control three-digit-width") }}&nbsp;minutes
+                        <label for="adjudication_time" class="me-2 text-nowrap"><strong>Adjudication Time:</span></strong></label>
+                        {{ form.adjudication_mins(class="form-control") }} <span class="ms-1 me-2">mins</span> 
+                        {{ form.adjudication_secs(class="form-control") }} <span class="ms-1">s</span>
                     </div>
                 </div>
-                <div class="col-xl-3 col-md-6 col-sm-6 col-12 mt-2">
+                <div class="col-xl-6 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center justify-content-md-end">
-                        <label for="warm-up_time" class="me-2"><strong>Warm-up Time:</strong></label>
-                        {{ form.move_time(class="form-control three-digit-width") }}&nbsp;minutes
+                        <label for="warm-up_time" class="me-2 text-nowrap"><strong>Warm-up Time:</strong></label>
+                        {{ form.move_mins(class="form-control") }} <span class="ms-1 me-2">mins</span> 
+                        {{ form.move_secs(class="form-control") }} <span class="ms-1">s</span>
                     </div>
                 </div>
             </div>

--- a/mfo/admin/templates/admin/partials/class_info_card_body.html
+++ b/mfo/admin/templates/admin/partials/class_info_card_body.html
@@ -1,9 +1,9 @@
 <div class="card-body">
     <div class="row">
-        <div class="col-xl-2 col-sm-4 col-md-3 col-12">
+        <div class="col-xl-2 col-sm-4 col-md-3 col-5">
             <p><strong>Number:</strong> {{ _class.number }}</p>
         </div>
-        <div class="col-xl-2 col-sm-3 col-12">
+        <div class="col-xl-2 col-sm-4 col-md-4 col-6">
             <p><strong>Suffix:</strong> {{ _class.suffix }}</p>
         </div>
         <div class="col-xl-8 col-12">
@@ -22,10 +22,10 @@
             <!-- spacer -->
         </div>
         <div class="col-xl-3 col-md-6 col-sm-6 col-12">
-            <p><strong>Adjudication Time:</strong> {{ _class.adjudication_time }} minutes</p>
+            <p><strong>Adjudication Time:</strong> {{ format_time(_class.adjudication_time) }}</p>
         </div>
         <div class="col-xl-3 col-md-6 col-sm-6 col-12 text-md-right">
-            <p><strong>Warm-up Time:</strong> {{ _class.move_time }} minutes</p>
+            <p><strong>Warm-up Time:</strong> {{ format_time(_class.move_time) }}</p>
         </div>
     </div>
 </div>

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -50,7 +50,7 @@
             <td>{{ _class.discipline }}</td>
             <td class="text-end">{{ _class.number_of_entries }}</td>
             <td class="text-end">{{ _class.total_fees }}</td>
-            <td class="text-end">{{ _class.total_time }}</td>
+            <td class="text-end">{{ format_time(_class.total_time, show_seconds=False) }}</td>
         </tr>
         
         {% endfor %}

--- a/mfo/admin/templates/admin/partials/entries_card_body.html
+++ b/mfo/admin/templates/admin/partials/entries_card_body.html
@@ -5,9 +5,9 @@
                 <li class="list-group-item">
                     <div class="row">
                         {% if entry.participants|length > 1 %}
-                        <div class="col-12 col-lg-3 col-xl-4">
+                        <div class="col-12 col-lg-3">
                         {% else %}
-                        <div class="col-12 col-lg-3 col-xl-2">
+                        <div class="col-12 col-lg-3">
                         {% endif %}
                             {% if _class.class_type == "Ensemble" %}
                                 {% for participant in entry.participants %}
@@ -20,14 +20,16 @@
                             {% endif %}
                         </div>
                         {% if entry.participants|length > 1 %}
-                        <div class="col-12 col-lg-9 col-xl-8">
+                        <div class="col-12 col-lg-9">
                         {% else %}
-                        <div class="col-12 col-lg-9 col-xl-10">
+                        <div class="col-12 col-lg-9">
                         {% endif %}
                             {% for piece in entry.repertoire %}
-                                <a href="{{ url_for('admin.repertoire_info_get', id=piece.id) }}">{{ piece.title }}</a> -- 
-                                {{ piece.composer }} -- 
-                                {{ piece.duration }} minutes<br>
+                                <a href="{{ url_for('admin.repertoire_info_get', id=piece.id) }}">{{ piece.title }}</a> 
+                                <span class="ms-1">--</span> 
+                                <span class="ms-1">{{ piece.composer }}</span> 
+                                <span class="ms-1">--</span> 
+                                {{ format_time(piece.duration) }}<br>
                             {% endfor %}
                         </div>
                     </div>

--- a/mfo/admin/templates/admin/repertoire_edit.html
+++ b/mfo/admin/templates/admin/repertoire_edit.html
@@ -33,28 +33,29 @@
                         {{ form.composer(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-sm-6 col-lg-4 col-xl-3 mt-2">
+                <div class="col-md-6 col-lg-4 col-xl-3 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="discipline" class="me-2"><strong>Discipline:</strong></label>
                         {{ form.discipline(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-sm-6 col-lg-4 col-xl-3 mt-2">
+                <div class="col-md-6 col-lg-4 col-xl-3 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="type" class="me-2"><strong>Type:</strong></label>
                         {{ form.type(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-sm-6 col-lg-4 col-xl-3 mt-2">
+                <div class="col-md-6 col-lg-4 col-xl-3 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="level" class="me-2"><strong>Level:</strong></label>
                         {{ form.level(class="form-control") }}
                     </div>
                 </div>
-                <div class="col-sm-6 col-lg-4 col-xl-3 mt-2">
+                <div class="col-sm-12 col-md-6 col-lg-4 col-xl-3 mt-2">
                     <div class="form-group d-flex align-items-center">
                         <label for="duration" class="me-2"><strong>Duration:</strong></label>
-                        {{ form.duration(class="form-control") }}
+                        {{ form.duration_mins(class="form-control") }} <span class="ms-1 me-2">mins</span> 
+                        {{form.duration_secs(class="form-control") }} <span class="ms-1">s</span>
                     </div>
                 </div>
                 <div class="col-12 mt-3">

--- a/mfo/admin/templates/admin/repertoire_info.html
+++ b/mfo/admin/templates/admin/repertoire_info.html
@@ -31,7 +31,7 @@
                     <p><strong>Level:</strong> {{ repertoire.level }}</p>
                 </div>
                 <div class="col-sm-6 col-lg-4 col-xl-3">
-                    <p><strong>Duration:</strong> {{ repertoire.duration }}&nbsp;minutes</p>
+                    <p><strong>Duration:</strong> {{ format_time(repertoire.duration) }}</p>
                 </div>
                 <div class="col-12">
                     <p class="mb-1"><strong>Description:</strong></p>

--- a/mfo/admin/templates/admin/repertoire_report.html
+++ b/mfo/admin/templates/admin/repertoire_report.html
@@ -35,16 +35,16 @@
                     sort_by=update_sort('level', sort_by[:], sort_order[:]), 
                     sort_order=update_order('level', sort_by[:], sort_order[:])) }}">Level</a>
                 </th>
-                <th>
+                <th class="time-width">
                     <a href="{{ url_for('admin.repertoire_get', 
                     sort_by=update_sort('duration', sort_by[:], sort_order[:]), 
                     sort_order=update_order('duration', sort_by[:], sort_order[:])) }}">Duration</a>
                 </th>
-                <th>
+                <!-- <th>
                     <a href="{{ url_for('admin.repertoire_get', 
                     sort_by=update_sort('classes', sort_by[:], sort_order[:]), 
                     sort_order=update_order('classes', sort_by[:], sort_order[:])) }}">Classes</a>
-                </th>
+                </th> -->
                 <th>
                     <a href="{{ url_for('admin.repertoire_get', 
                     sort_by=update_sort('entries', sort_by[:], sort_order[:]), 
@@ -60,8 +60,8 @@
                 <td>{{ piece.discipline }}</td>
                 <td>{{ piece.type }}</td>
                 <td>{{ piece.level }}</td>
-                <td class="text-center">{{ piece.duration }}</td>
-                <td class="text-center">{{ piece.classes }}</td>
+                <td>{{ format_time(piece.duration) }}</td>
+                <!-- <td class="text-center">{{ piece.classes }}</td> -->
                 <td class="text-center">{{ piece.entries }}</td>
             </tr>
             

--- a/mfo/config.py
+++ b/mfo/config.py
@@ -101,24 +101,24 @@ TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
 
 # Class default data
 DEFAULT_ADJUDICATION_TIME = {
-    'Solo': 10,
-    'Recital': 15,
-    'Duet': 15,
-    'Trio': 20,
-    'Quartet': 25,
-    'Quintet': 30,
-    'Ensemble': 35,
-    'Composition': 10,
+    'Solo': 600,  # times are in seconds
+    'Recital': 900,
+    'Duet': 900,
+    'Trio': 1200,
+    'Quartet': 1500,
+    'Quintet': 1800,
+    'Ensemble': 2100,
+    'Composition': 600,
 }
 DEFAULT_MOVE_TIME = {
-    'Solo': 2,
-    'Recital': 4,
-    'Duet': 3,
-    'Trio': 4,
-    'Quartet': 5,
-    'Quintet': 5,
-    'Ensemble': 5,
-    'Composition': 2,
+    'Solo': 120, # times are in seconds
+    'Recital': 240,
+    'Duet': 180,
+    'Trio': 240,
+    'Quartet': 300,
+    'Quintet': 300,
+    'Ensemble': 300,
+    'Composition': 120,
 }
 DEFAULT_FEE = {
     'Solo': 12,
@@ -130,4 +130,17 @@ DEFAULT_FEE = {
     'Ensemble': 25,
     'Composition': 12,
 }
+
+DISCIPLINES = [
+    "Vocal", 
+    "Piano", 
+    "Organ", 
+    "Strings",
+    "Recorder",
+    "Woodwinds",
+    "Brass",
+    "Percussion",
+    "Instrumental",
+    "Musical Theatre",
+    ]
 

--- a/mfo/template_functions.py
+++ b/mfo/template_functions.py
@@ -1,6 +1,7 @@
 # mfo/template_functions.py
 
 import flask
+from markupsafe import Markup
 
 bp = flask.Blueprint(
     'jinja_functions',
@@ -39,3 +40,18 @@ def update_order(column, sort_by, sort_order):
 # Add helper functions to Jinja2 environment
 # app.jinja_env.globals.update(update_sort=update_sort)
 # app.jinja_env.globals.update(update_order=update_order)
+
+@bp.app_template_global()
+def format_time(seconds, show_seconds=True):
+    if seconds is None:
+        return "None"
+    
+    if show_seconds:
+        minutes, remaining_seconds = divmod(seconds, 60)
+        if remaining_seconds:
+            return Markup(f"<span class='ms-1'></span>{minutes:2d}<span class='ms-1 me-2'>min</span>{remaining_seconds:2d}<span class='ms-1'>s</span>")
+        else:
+            return Markup(f"<span class='ms-1'></span>{minutes:2d}<span class='ms-1'>min</span>")
+    else:
+        rounded_minutes = round(seconds / 60)
+        return Markup(f"<span class='ms-1'></span>{rounded_minutes:2d}<span class='ms-1'>min</span>")


### PR DESCRIPTION
Change the admin blueprint so that times are recorded in seconds and displayed as minutes/seconds.

#### models.py

No changes needed in the code, but the following fields will contain an integer representing "seconds", instead of "minutes":

- FestivalClass().adjudication_time
- FestivalClass().move_time
- Repertoire().duration

#### spreadsheet.py

Add some logic to detect where times or durations are entered in minutes and convert to seconds. Detect where they were probably entered as seconds (a large integer)

```
# mfo/admin/services/spreadsheet.py

def convert_to_seconds(time_value):
    """Convert time value to seconds. If the value is large, assume it's already in seconds."""
    if time_value > 30:
        return time_value  # Assume it's already in seconds
    return time_value * 60  # Convert minutes to seconds
```

Then, I went through the functions in the spreadsheet looking for places to apply the *convert_to_seconds()* function. I use the *duration* variable name too much in the *spreadsheets.py* module so it's confusing when to apply the function. 

Everywhere I am reading row from the dataframe, *input_df* and check if the value in the duration column of the piece I am reading is not NaN, then I used the *convert_to_seconds()* function. So, everywhere I saw the following, or similar, code:

```
if pd.notna(duration):
    duration = int(duration)
```

I changed it to:

```
if pd.notna(duration):
    duration = convert_to_seconds(int(duration))
```

This turned out to be in 4 places in the code.

The places where I read in the adjudication time and move time were easier to fix. I just changed the configuration variables, ADJUDICATION_TIME or MOVE_TIME in the *config.py* file from minutes to seconds. For example, I changed:

```
DEFAULT_ADJUDICATION_TIME = {
    'Solo': 10,  # times are in seconds
    'Recital': 15,
    'Duet': 15,
    'Trio': 20,
    'Quartet': 25,
    'Quintet': 30,
    'Ensemble': 35,
    'Composition': 10,
}
```

To:

```
DEFAULT_ADJUDICATION_TIME = {
    'Solo': 600,  # times are in seconds
    'Recital': 900,
    'Duet': 900,
    'Trio': 1200,
    'Quartet': 1500,
    'Quintet': 1800,
    'Ensemble': 2100,
    'Composition': 600,
}
```

#### mfo/template_functions.py

Create a helper function in the *mfo/template_functions.py* module that will automatically convert seconds to minutes/seconds in the template:

```
@bp.app_template_global()
def format_time(seconds, show_seconds=True):
    if show_seconds:
        minutes, remaining_seconds = divmod(seconds, 60)
        if remaining_seconds
            return f"{minutes:2d} minutes {remaining_seconds:2d} seconds"
        else:
            return f"{minutes:2d} minutes"
    else:
        rounded_minutes = round(seconds / 60)
        return f"{rounded_minutes:2d} minutes"
```

I also added two other helper functions that return just integers, for use in populating edit forms:

```
@bp.app_template_global()
def minutes(seconds):
    return seconds // 60

@bp.app_template_global()
def remaining_seconds(seconds):
    return seconds % 60
```

#### Templates

Change time so the "seconds" stored in the database is presented as "minutes" and "seconds" in the template.

In most templates, I simply added the new *format_time()* helper function to the html code, as shown in the example below:

```
{{ format_time(piece.duration) }}
```

I made changes to the following the following templates:

- partials/class\_info\_card_body.html
- partials/entries\_card\_body.html
- partials/class\_table.html
- repertoire\_edit.html
- repertoire\_info.html
- repertoire\_report.html
- class\_edit\_info.html

#### View functions

To support separate "minutes" and "seconds" fields in the editing forms, I changed the *repertoire_edit_get()* and *repertoire_edit_post()* view functions. 

In the *get* view function I calculate the minutes and seconds from total seconds and add them as separate attributes to the *repertoire* object:

```
duration_mins, duration_secs = divmod(repertoire.duration, 60)
form.duration_mins.data = duration_mins
form.duration_secs.data = duration_secs
```

In the *post* view function, I get the separate objects using the *flask.request()* method then calculate total seconds and add it to the ORM object, *repertoire*.

```
minutes = int(flask.request.form['duration_mins'])
seconds = int(flask.request.form['duration_secs'])
total_seconds = minutes * 60 + seconds
repertoire.duration = total_seconds 
```

Also changed the *edit_class_info_get()* and *edit_class_info_post()* view functions.

In the *get* view function I calculate the adjudication and move minutes and seconds from total seconds and add them as separate attributes to the *_class* object:

```
adjudication_mins, adjudication_secs = divmod(_class.adjudication_time, 60)
form.adjudication_mins.data = adjudication_mins
form.adjudication_secs.data = adjudication_secs
move_mins, move_secs = divmod(_class.move_time, 60)
form.move_mins.data = move_mins
form.move_secs.data = move_secs
```

In the *post* function I convert minutes and seconds back to total seconds and add the numbers to the *_class* object's *adjudication_time* and *move_time* attributes. 

```
minutes = int(flask.request.form['adjudication_mins'])
seconds = int(flask.request.form['adjudication_secs'])
total_seconds = minutes * 60 + seconds
_class.adjudication_time = total_seconds
minutes = int(flask.request.form['move_mins'])
seconds = int(flask.request.form['move_secs'])
total_seconds = minutes * 60 + seconds
_class.move_time = total_seconds
```

### Forms

In the */admin/forms.py* module, I modified the *EditRepertoireForm()* and *EditClassBasicInfoForm()* forms.

In the the *EditRepertoireForm()* form, I removed *duration* field and then replaced it with the *duration_mins* and *duration_secs* fields.

```
duration_mins = IntegerField('Minutes', validators=[InputRequired()])
duration_secs = IntegerField('Seconds', validators=[InputRequired()])
```

In the *EditClassBasicInfoForm()* form, I removed *adjudication_time* and *move_time* and replaced them with the *mins* and *seconds* fields for each:

```
adjudication_mins = IntegerField('Adjudication Minutes', validators=[InputRequired()])
adjudication_secs = IntegerField('Adjudication Seconds', validators=[InputRequired()])
move_mins = IntegerField('Move Minutes', validators=[InputRequired()])
move_secs = IntegerField('Move Seconds', validators=[InputRequired()])
```

I learned that the *DataRequired* validator will fail if you enter "0" in the field. To support inputs of zero, I had to use the *InputRequired* validator.


