### PR TITLE
Deploy to sever

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ cython_debug/
 
 # Environment variables file
 .dotenv
+*.env
 
 # Libreoffice Calc files
 *.ods
@@ -170,3 +171,6 @@ cython_debug/
 
 # Flask-Session
 session/
+
+
+settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -143,22 +143,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 .dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+dmypy.jsonk) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
 # Environment variables file
@@ -174,3 +159,8 @@ session/
 
 
 settings.json
+
+
+# certificare files
+*.pem
+*.pub

--- a/deploy/app/dockerfile
+++ b/deploy/app/dockerfile
@@ -20,9 +20,10 @@ RUN apt-get update && apt-get install -y \
 COPY --from=first-stage /ps-install /usr/local
 
 WORKDIR /mfo-app
-COPY mfo/  ./mfo
-COPY tests/  ./tests
-COPY production.env requirements-prod.txt ./
+COPY requirements-prod.txt ./
+# COPY mfo/  ./mfo
+# COPY tests/  ./tests
+# COPY production.env requirements-prod.txt ./
 
 ENV FLASK_APP="mfo.app"
 ENV FLASK_ENV="production"

--- a/deploy/app/dockerfile
+++ b/deploy/app/dockerfile
@@ -29,6 +29,6 @@ ENV FLASK_ENV="production"
 
 RUN pip install --no-cache-dir -r requirements-prod.txt
 
-EXPOSE 5000
+EXPOSE 8000
 
-ENTRYPOINT ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "mfo.wsgi:app"]
+ENTRYPOINT ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "mfo.wsgi:app"]

--- a/deploy/app/dockerfile
+++ b/deploy/app/dockerfile
@@ -21,9 +21,6 @@ COPY --from=first-stage /ps-install /usr/local
 
 WORKDIR /mfo-app
 COPY requirements-prod.txt ./
-# COPY mfo/  ./mfo
-# COPY tests/  ./tests
-# COPY production.env requirements-prod.txt ./
 
 ENV FLASK_APP="mfo.app"
 ENV FLASK_ENV="production"

--- a/deploy/app/dockerfile
+++ b/deploy/app/dockerfile
@@ -1,0 +1,34 @@
+# FIRST STAGE
+FROM python:3.12-slim AS first-stage
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    python3-setuptools
+
+RUN pip install --no-cache-dir --prefix=/ps-install psycopg2
+
+# FINAL STAGE
+FROM python:3.12-slim AS final-stage
+
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    default-jre \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=first-stage /ps-install /usr/local
+
+WORKDIR /mfo-app
+COPY mfo/  ./mfo
+COPY tests/  ./tests
+COPY production.env requirements-prod.txt ./
+
+ENV FLASK_APP="mfo.app"
+ENV FLASK_ENV="production"
+
+RUN pip install --no-cache-dir -r requirements-prod.txt
+
+EXPOSE 5000
+
+ENTRYPOINT ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "mfo.wsgi:app"]

--- a/deploy/nginx/certs/host/commands.txt
+++ b/deploy/nginx/certs/host/commands.txt
@@ -1,0 +1,19 @@
+In *deploy/nginx/certs/host/* run the following command
+
+```
+ssh-keygen -t rsa -b 4096 -m PEM
+```
+
+When asked where to store the key, put it in the *deploy/nginx/certs/host/* directory by entering in the relative path with filename which, in my case, is: `key.pem`.
+
+This results in two files being created: *key.pem* AND *key.pem.pub*.
+
+Then, create the cert
+
+```
+openssl req -new -x509 -key key.pem -out cert.pem -days 100
+```
+
+The private key is *key.pem* and the certificate is *cert.pem*. So those are the files to use as the certificate and the key that signs the certificate
+
+And, of course, add the private key and certificate files to your *.gitignore* file:

--- a/deploy/nginx/configs/host/nginx.conf
+++ b/deploy/nginx/configs/host/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_tokens off;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_tokens off;
+    ssl_certificate /etc/nginx/certs/cert.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey;
+    location / {
+        proxy_pass http://mfo-app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        
+    }
+}

--- a/deploy/nginx/configs/host/nginx.conf
+++ b/deploy/nginx/configs/host/nginx.conf
@@ -1,16 +1,18 @@
 server {
     listen 80;
+    server_name local.musicfestivalorganizer.com;
     server_tokens off;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    server_name local.musicfestivalorganizer.com;
     server_tokens off;
     ssl_certificate /etc/nginx/certs/cert.pem;
-    ssl_certificate_key /etc/nginx/certs/privkey;
+    ssl_certificate_key /etc/nginx/certs/key.pem;
     location / {
-        proxy_pass http://mfo-app:8000;
+        proxy_pass http://app:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Protocol $scheme;

--- a/deploy/nginx/configs/server/nginx.conf
+++ b/deploy/nginx/configs/server/nginx.conf
@@ -14,7 +14,7 @@ server {
     ssl_certificate_key /etc/nginx/certs/privkey.pem;
 
     location / {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://app:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Protocol $scheme;

--- a/deploy/nginx/configs/server/nginx.conf
+++ b/deploy/nginx/configs/server/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name musicfestivalorganizer.com *.musicfestivalorganizer.com;
+    server_tokens off;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name musicfestivalorganizer.com;
+    server_tokens off;
+    
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -50,11 +50,11 @@ services:
       - "443:443"
     volumes:
       - type: bind
-        source: ./deploy/nginx/configs/host
+        source: ./deploy/nginx/configs/server
         target: /etc/nginx/conf.d
         read_only: true
       - type: bind
-        source: ./deploy/nginx/certs/host
+        source: ./deploy/nginx/certs/server
         target: /etc/nginx/certs
         read_only: true
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,19 @@ name: mfo
 services:
   app:
     image: mfo-app
+    volumes:
+      - type: bind
+        source: ./mfo
+        target: /mfo-app/mfo
+        read_only: true
+      - type: bind
+        source: ./tests
+        target: /mfo-app/tests
+        read_only: true
+      - type: bind
+        source: ./production.env
+        target: /mfo-app/production.env
+        read_only: true
     networks:
       - frontend_network
       - backend_network
@@ -18,7 +31,7 @@ services:
       POSTGRES_DB: postgres
     volumes:
       - type: volume
-        source: mfo-data
+        source: data
         target: /var/lib/postgresql/data
     networks:
       - backend_network
@@ -59,4 +72,4 @@ networks:
     driver: bridge
 
 volumes:
-  mfo-data:
+  data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+name: mfo
+
+services:
+  app:
+    image: mfo-app
+    networks:
+      - frontend_network
+      - backend_network
+    depends_on:
+      - db
+      - cache
+
+  db:
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: fake-password
+      POSTGRES_DB: postgres
+    volumes:
+      - type: volume
+        source: mfo-data
+        target: /var/lib/postgresql/data
+    networks:
+      - backend_network
+
+  cache:
+    image: redis
+    networks:
+      - backend_network
+
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - type: bind
+        source: ./deploy/nginx/configs/host
+        target: /etc/nginx/conf.d
+        read_only: true
+      - type: bind
+        source: ./deploy/nginx/certs/host
+        target: /etc/nginx/certs
+        read_only: true
+    networks:
+      - frontend_network
+      - external_network
+    depends_on:
+      - app
+
+networks:
+  backend_network:
+    driver: bridge
+    internal: true
+  frontend_network:
+    driver: bridge
+    internal: true
+  external_network:
+    driver: bridge
+
+volumes:
+  mfo-data:

--- a/docs/dotenv_example
+++ b/docs/dotenv_example
@@ -1,25 +1,30 @@
-# Application variables
-# ---------------------
-FLASK_ENVIRONMENT = development
-FLASK_APP = app
-FLASK_DEBUG = True
+# /production.env
+
+FLASK_ENVIRONMENT = production
 # Generate a key using "secrets.token_urlsafe()"
 FLASK_SECRET_KEY = LGBoUEDCCpgwxy5jZxpu9e01MTnRVqnG6A8ceD7Z4YU
-# FLASK_SERVER_NAME = 127.0.0.1:5000
 FLASK_EXPLAIN_TEMPLATE_LOADING = False
-
 
 # Flask-SQLAlchemy variables
 # --------------------------
-# The connection string of the app's database.
-SQLALCHEMY_DATABASE_URI = ""
-# Print database-related actions to the console for debugging purposes.
+SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://postgres:fake-password@mfo-db:5432/postgres"
 SQLALCHEMY_ECHO = False
 
+# Flask-Session variables
+# -----------------------
+SESSION_TYPE = "redis"
+PERMANENT_SESSION_LIFETIME = 2678400
+
+# Redis variables
+# ---------------
+REDIS_URL = "redis://mfo-cache:6379"
 
 # Flask-Security variables
-# ---------------------
+# ------------------------
 # generate a salt using "secrets.SystemRandom().getrandbits(128)"
 SECURITY_PASSWORD_SALT  = 307680677384259925768439955171685999662
 
-TEST_USERS_FILE = "/home/brian/Projects/Music Festival Program/music-festival-organizer/tests/test_users.json"
+# command line variables
+# ----------------------
+TEST_USERS_FILE = "/mfo-app/tests/test_users.json"
+TEST_FESTIVALS_FILE = "/mfo-app/tests/test_festivals.json"

--- a/mfo/config.py
+++ b/mfo/config.py
@@ -34,7 +34,7 @@ SECURITY_POST_LOGIN_VIEW = '/'
 SECURITY_POST_REGISTER_VIEW = '/new_user'
 
 # Flask-SQLAlchemy variables
-if ENVIRONMENT == "development":
+if ENVIRONMENT == "development" or ENVIRONMENT == "lightweight":
     # For development, use a SQLite database located in the project folder
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(project_dir, 'app.sqlite')
 else:
@@ -112,7 +112,11 @@ ROLES  = {
     },
 }
 
-TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
+if ENVIRONMENT == "development" or ENVIRONMENT == "lightweight":
+    TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
+    TEST_USERS_FILE = os.path.join(project_dir, TEST_USERS_FILE)
+else:
+    TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
 
 
 # Class default data

--- a/mfo/config.py
+++ b/mfo/config.py
@@ -1,12 +1,18 @@
 # mfo/config.py
 
 import os
-import dotenv
+from dotenv import load_dotenv
 from decimal import Decimal
+import redis
+from datetime import timedelta
+from cachelib import FileSystemCache
+
 
 app_dir = os.path.abspath(os.path.dirname(__file__))
 project_dir = os.path.dirname(app_dir)
-dotenv.load_dotenv()
+
+FLASK_ENV = os.getenv('FLASK_ENV')
+load_dotenv(dotenv_path=f'{project_dir}/{FLASK_ENV}.env')
 
 # General Config
 ENVIRONMENT = os.environ.get("FLASK_ENVIRONMENT")
@@ -30,8 +36,7 @@ SECURITY_POST_REGISTER_VIEW = '/new_user'
 # Flask-SQLAlchemy variables
 if ENVIRONMENT == "development":
     # For development, use a SQLite database located in the project folder
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")\
-        or 'sqlite:///' + os.path.join(project_dir, 'app.sqlite')
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(project_dir, 'app.sqlite')
 else:
     # For production, get the database URI from environment variable
     SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
@@ -43,13 +48,23 @@ SQLALCHEMY_TRACK_MODIFICATIONS = os.environ.get("SQLALCHEMY_TRACK_MODIFICATIONS"
 SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}  
 
 # Flask-Session variables
-SESSION_TYPE = 'filesystem'
-SESSION_FILE_DIR = os.path.join(project_dir, 'session')
-SESSION_FILE_THRESHOLD = 50
-SESSION_PERMANENT = False
-SESSION_USE_SIGNER = True
-#SESSION_SERIALIZATION_FORMAT = 'json'
+SESSION_TYPE = os.environ.get('SESSION_TYPE')
+SESSION_PERMANENT = True
+PERMANENT_SESSION_LIFETIME = timedelta(
+    seconds=int(os.environ.get("PERMANENT_SESSION_LIFETIME"))
+)
 
+if SESSION_TYPE == 'filesystem':
+    SESSION_TYPE = 'cachelib'
+    SESSION_THRESHOLD = int(os.environ.get('SESSION_THRESHOLD')) 
+    SESSION_CACHELIB = FileSystemCache(
+        threshold=SESSION_THRESHOLD, 
+        cache_dir=os.path.join(project_dir, 'session'),
+        default_timeout=PERMANENT_SESSION_LIFETIME.total_seconds()
+    )
+else:
+    SESSION_TYPE = 'redis'
+    SESSION_REDIS = redis.Redis.from_url(os.environ.get('REDIS_URL'))
 
 
 # Roles defined

--- a/mfo/database/commands.py
+++ b/mfo/database/commands.py
@@ -74,7 +74,7 @@ def test_users():
 @bp.cli.command('create')
 @flask.cli.with_appcontext
 def create():
-    db.drop_all()
+    #db.drop_all()
     db.create_all()
 
     roles_dict = flask.current_app.config['ROLES']

--- a/mfo/wsgi.py
+++ b/mfo/wsgi.py
@@ -1,0 +1,5 @@
+# mfo/wsgi.py
+
+from mfo.app import create_app
+
+app = create_app()

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,0 +1,17 @@
+# requirements.txt
+
+setuptools
+flask
+python-dotenv
+Flask-Security-Too[fsqla,common]
+bootstrap-flask
+phonenumbers
+pandas
+odfpy
+openpyxl
+Flask-Session[cachelib]
+tabula-py[jpype]
+redis
+cachelib
+psycopg2
+gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ odfpy
 openpyxl
 Flask-Session[cachelib]
 tabula-py[jpype]
+redis
+cachelib
+psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # requirements.txt
 
+setuptools
 flask
 python-dotenv
 Flask-Security-Too[fsqla,common]


### PR DESCRIPTION
# Create a production environment

My app has been using an SQLite database and using the host's filesystem to cache session data. Now, I need to modify it so it can operate in a real production environment

The production environment will use a Postgress database server and a Redis cache server. Both these servers will run in containers on the same host as the web app. 

The Postgress server's connection string will be similar to the one shown below, with your own username and password. Note that we haven't set up a Postgress container, yet.

```
"postgresql+psycopg2://user-name:your-own-password@localhost:5432/mfo"
```

The Redis Cache server's URL will be:

```
"redis://localhost:6379"
```

# Add packages

In *requirements.txt*, add the *Redis* and *CacheLib* packages:

```
# requirements.txt

# ...
redis
cachelib
psycopg2-binary
```

The install the new packages in your virtual environment, run the command:

```
(.venv) $ pip install -r requirements.txt
```

### Issues with *psycopg2*

The [*psycopg2* page on pypi.org](https://pypi.org/project/psycopg2/) states that the *psycopg2-binary* package is a practical choice for development and testing but in production it is advised to use the package built from sources. However, I cannot find a way to install *psycopg2* unless I first install *postgres* on the system, which seems unnecessary to me.

On a production server, install *psycopg2* from source. First, install the PostgreSQL development libraries and headers.

```
$ sudo apt update
$ sudo apt install libpq-dev python3-dev libpq-dev
$ sudo apt install build-essential
```

Since I don't want to install postgres on my laptop, the solution is to create a container for the web app so I can build the production environment without adding unnecessary software to my system.

I'll cover creating a web app container, later.


## Environment files

I need to create a new dotenv file for the production environment. I will rename the existing .env file *development.env* and copy it to create a new file named *production.env*.

In *production.env*, replace or add the following lines

```
# Flask-SQLAlchemy variables
# --------------------------
SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://postgres:fake-password@localhost:5432/postgres"
SQLALCHEMY_ECHO = False

# Flask-Session variables
# -----------------------
SESSION_TYPE = "redis"
PERMANENT_SESSION_LIFETIME = 2678400

# Redis variables
# ---------------
REDIS_URL = "redis://localhost:6379"
```

And in *development.env*, add the following line:

```
# Flask-Session variables
# -----------------------
SESSION_TYPE = "filesystem"
SESSION_THRESHOLD = 5
PERMANENT_SESSION_LIFETIME = 1500
```

In the *mfo/config.py* module, add the following code to set which dotenv file will be used, depending on the environment variable, *APP_ENV*.

```
# ...
from dotenv import load_dotenv

# ...
FLASK_ENV = os.getenv('FLASK_ENV')
load_dotenv(dotenv_path=f'{project_dir}/{FLASK_ENV}.env')
# ...
```

Add the following to the .gitignore file so the dotenv files do not get saved in git or on GitHub:

```
# .gitignore

# Environment variables files
*.env
```

## Modernize the filesystem cache

Flask-Session has deprecated the [filesystem](https://flask-session.readthedocs.io/en/latest/config.html#filesystem) storage type. Instead we must use [CacheLib's *FileSystemCache* class](https://cachelib.readthedocs.io/en/latest/file/#module-cachelib.file), which can be accessed by importing cachelib or by creating an instance of the [*flask_session.filesystem.FileSystemSessionInterface*](https://flask-session.readthedocs.io/en/latest/api.html#flask_session.filesystem.FileSystemSessionInterface) class, which the *cachelib.file.FileSystemCache* class. I chose to use *CacheLib* directly, because I thought using *flask_session.filesystem* was a bit confusing since the Flask-Session docs say "filesystem" is deprecated.

```
# mfo/config.py

# ...other imports
import redis
from datetime import timedelta
from cachelib import FileSystemCache

# ...


# ...
# Flask-SQLAlchemy variables
if ENVIRONMENT == "development":
    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(project_dir, 'app.sqlite')
else:
    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
SQLALCHEMY_ECHO = os.environ.get("SQLALCHEMY_ECHO")
SQLALCHEMY_TRACK_MODIFICATIONS = os.environ.get("SQLALCHEMY_TRACK_MODIFICATIONS")
SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}  

# Flask-Session variables
SESSION_TYPE = os.environ.get('SESSION_TYPE')
SESSION_PERMANENT = True
PERMANENT_SESSION_LIFETIME = timedelta(
    seconds=int(os.environ.get("PERMANENT_SESSION_LIFETIME"))
)

if SESSION_TYPE == 'filesystem':
    SESSION_TYPE = 'cachelib'
    SESSION_THRESHOLD = int(os.environ.get('SESSION_THRESHOLD')) 
    SESSION_CACHELIB = FileSystemCache(
        threshold=SESSION_THRESHOLD, 
        cache_dir=os.path.join(project_dir, 'session'),
        default_timeout=PERMANENT_SESSION_LIFETIME.total_seconds()
    )
else:
    SESSION_TYPE = 'redis'
    SESSION_REDIS = redis.Redis.from_url(os.environ.get('REDIS_URL'))

    
# Roles, etc. ...
```

I also added configuration for a Redis-based cache, to be used in the production environment.

## Run app in development environment

Now, every time you run the app you need to ensure the FLASK_ENV environment variable is set to either "development" or "production". Some day I may add a "test" environment.

I don't have a default environment because I worry that that might make it possible to deploy the app in the wrong environment by mistake.

To run the app in a development environment, which uses SQLite for the database and uses the filesystem for the session cache, run the following command:

```
export FLASK_ENV=development
flask --app mfo.app run --debug
```

Running the app in a production environment will be more complex because we have to create Redis and Postgresql resources, first.

Now, to create the production environment, create a Redis container and a Postgress container:

## Install Docker

The following steps are all from the [Docker install guide](https://docs.docker.com/engine/install/ubuntu/) in the Docker documentation.

First, install prerequisite packages and add the Docker repository to your apt sources list:

```
# Add Docker's official GPG key:
sudo apt update
sudo apt install ca-certificates curl
sudo install -m 0755 -d /etc/apt/keyrings
sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
sudo chmod a+r /etc/apt/keyrings/docker.asc

# Add the repository to Apt sources:
echo \
  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt update
```

Then, install the docker packages:

```
sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
```

Test that docker works:

```
sudo docker run hello-world
```

You should see a "Hello from Docker" message along with some helpful information.

To [use Docker without having to invoke *root* privileges](https://docs.docker.com/engine/install/linux-postinstall/), run the following commands:

```
sudo groupadd docker
sudo usermod -aG docker $USER
newgrp docker
```

The test again without using `sudo`:

```
docker run hello-world
```

## Create a Postgress database container

https://learningwithcode.com/postgressql-on-docker-container

Simply [download and run the Postgress image from Docker Hub](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/), and configure it when you run it:

```
docker run \
  --detach \
  --env POSTGRES_USER=postgres \
  --env POSTGRES_PASSWORD=fake-password \
  --env POSTGRES_DB=postgres \
  --network host \
  --name db \
  postgres
```



## Create a Redis cache container

[Download and run the Redis container](https://www.docker.com/blog/how-to-use-the-redis-docker-official-image/) from Docker Hub

```
docker run \
  --detach \
  --network host \
  --name cache \
  redis
```

## Test the production environment

Before containerizing the web app for deployment, test the app in the production environment:

```
export FLASK_ENV=production
flask --app mfo.app run &
flask --app mfo.app database create
flask --app mfo.app database test_users
```

After logging in as a user, check that the Redis instance has a session cached:

```
docker exec cache redis-cli KEYS "*"
```

You should see an output like:

```
1) "session:PMExLBkw9jtZVnBhgilknN3QwjGK9sT6SPgWN0cElig"
```

## Problem dropping tables

After testing the production environment, I saw that Postgres raises an error when deleting all tables in the database:

```
An error occurred: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (psycopg2.errors.ForeignKeyViolation) update or delete on table "profile" violates foreign key constraint "user_primary_profile_id_fkey" on table "user" DETAIL: Key (id)=(1) is still referenced from table "user". [SQL: DELETE FROM profile WHERE profile.id = %(id)s] [parameters: [{'id': 1}, {'id': 2}, {'id': 306}, {'id': 344}, {'id': 349}, {'id': 358}, {'id': 364}, {'id': 365} ... displaying 10 of 225 total bound parameter sets ... {'id': 592}, {'id': 593}]] (Background on this error at: https://sqlalche.me/e/20/gkpj) 
```

This is because the *user.primary_profile_id* column is referencing the *profile.id* column, and you cannot delete a profile that is still set as a primary profile for any user.

After investigating, I decided to rewrite the database delete view function so that registered users would remain in the database, along with their primary profiles. And, I clean up the *profiles_roles* table.

```
# mfo/admin/views.py

# ...
from mfo.database.models import Profile, FestivalClass, Repertoire, profiles_roles

# ...
@bp.post('/delete/festival_data')
@flask_security.auth_required()
@flask_security.roles_required('Admin')
def delete_festival_data_post():
    form = forms.ConfirmFestivalDataDelete()
    if form.validate_on_submit():
        if flask_security.utils.verify_and_update_password(form.password.data, flask_security.current_user):
            try:
                with db.session.no_autoflush:     
                    # Get list of users
                    users = db.session.scalars(select(User)).all()
                    roles = db.session.scalars(select(Role)).all()
                    
                    # Delete all profiles, except the profiles that are user's primary profiles
                    stmt = select(User.primary_profile_id).where(User.primary_profile_id.isnot(None))
                    primary_profile_ids = db.session.execute(stmt).scalars().all()

                    # Find profiles that are not primary profiles
                    stmt = select(Profile).where(Profile.id.notin_(primary_profile_ids))
                    profiles_to_delete = db.session.execute(stmt).scalars().all()

                    # Delete the profiles
                    for profile in profiles_to_delete:
                        db.session.execute(profiles_roles.delete().where(profiles_roles.c.profile_id == profile.id))
                        db.session.delete(profile)                                
               
                    # Clear all remaining data except User and Role data
                    meta = db.metadata
                    for table in reversed(meta.sorted_tables):
                        if table.name not in ['user', 'role', 'profile', 'roles_users', 'profiles_roles']:
                            db.session.execute(table.delete())
                    
                    db.session.commit()
                    flask.flash('Festival data has been deleted.', 'success')
```

### Future problems 

This works, for now, because I expect only a few administrative users will be set up in this single-tenant system and all other data is imported from a spreadsheet. However, when I generalize this to a multi-tenant system where normal users will set up accounts and register multiple participant profiles, I will need to carefully clear all related data before deleting profiles, classes, etc. 

Of course, in the generalized, multi-tenant system, I would not allow the complete deletion of all festival data. I would have to create a function that removes season-related data in each festival and then create a separate app for the system admin to clean up festivals, etc.


## Create a web app container

To test deployment on your laptop and to create a container that can be deployed, create a web app container by building one from a Dockerfile

### Update the *production.env* file

Since the test files will be in the working directory in the container, I need to change the variables in the *deployment.env* file to point to the container's working directory:

Replace the following lines in *production.env*:

```
# command line variables
# ----------------------
TEST_USERS_FILE = "/mfo-app/tests/test_users.json"
TEST_FESTIVALS_FILE = "/mfo-app/tests/test_festivals.json"
```

### Create two requirements files

The production environment needs the plan *psycopg2* package and also needs *gunicorn*, Make a copy of *requirements.txt* and call it *requirements-prod.txt*.

In requirements.prod, add the following lines:

```
# requirements.prod

# ...
psycopg2
gunicorn
```

### Create wsgi entry point

To run the app with Gunicorn, I need to create a wsgi entry point that simply creates an instance of the app for gunicorn.

In the project's *mfo* directory, add the file named *wsgi.py*:

```
# mfo/wsgi.py

from mfo.app import create_app

app = create_app()
```

### Docker file for web app

Create a Dockerfile in a sub-directory in your project directory. Since I plan to have multiple containers supporting my web app, I created a sub-directory named *deploy* and added the *app* and *nginx* sub-directories in it.  I created a file named "dockerfile" in the *./deploy/app* directory..

https://wbarillon.medium.com/docker-python-image-with-psycopg2-installed-c10afa228016
https://docs.docker.com/guides/python/containerize/

I don't need the *build-essentials* package after installing *psycopg2* so I can create a smaller container by running a multi-stage build.

```
# FIRST STAGE
FROM python:3.12-slim AS first-stage

RUN apt-get update && apt-get install -y \
    build-essential \
    libpq-dev \
    python3-setuptools

RUN pip install --no-cache-dir --prefix=/ps-install psycopg2

# FINAL STAGE
FROM python:3.12-slim AS final-stage

RUN apt-get update && apt-get install -y \
    libpq-dev \
    default-jre \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*

COPY --from=first-stage /ps-install /usr/local

ENV FLASK_APP="mfo.app"
ENV FLASK_ENV="production"

RUN pip install --no-cache-dir -r requirements-prod.txt

EXPOSE 8000

ENTRYPOINT ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "mfo.wsgi:app"]
```

### The *.dockerignore* file

A *.dockerignore* file prevents unneeded files being copied from the project. 

I like to use a [standard *.gitignore* template for Python projects](https://gist.github.com/KernelA/04b4d7691f28e264f72e76cfd724d448). It includes many different files that you don't want to copy to a container. The most important files are shown in the snippet below:

```
# Git
.git
.gitignore
.gitattributes

# Docker
docker-compose.yml
Dockerfile
.docker
.dockerignore

# Byte-compiled / optimized / DLL files
**/__pycache__/

# Virtual environment
.env
.venv/
venv/

# VS Code
.vscode/
```

This will reduce the size of the resulting image and prevent sensitive information from being exposed in your image. The *\_\_pycache\_\_* directories in particular can add many megabytes to a container image.

Then, test the Dockerfile by running the Docker build command. In this example, you need to be in the project folder, not in deploy/app. You need to specify the dockerfile and the [build context](https://docs.docker.com/build/concepts/context/) (which is the directory from which the dockerfile will assume it is copying files).

In this case, the dockerfile is *./deploy/app/dockerfile* and the build context is the current directory, *"."*.

```
$ docker build \
    --tag mfo-app \
    --file ./deploy/app/dockerfile \
    .
```

## Test the container

```
$ pwd
(shows I am in project folder)
```

```
$ docker run --detach \
    --name app \
    --network=bridge \
    --volume=./mfo:/mfo-app/mfo:ro \
    --volume=./tests:/mfo-app/tests:ro \
    --volume=./production.env:/mfo-app/production.env:ro \
    mfo-app
```





```
$ docker exec app flask database create
$ docker exec app flask database test_users
```

Test the app

```
http://localhost:5000
```

Shut down the containers

```
$ docker stop app db cache
```

Clean up all containers

```
$ docker container prune
```

## The nginx container

Finally, to create a secure reverse proxy that can handle a domain name and HTTPS certificates, create an NGINX container

### NGINX on host PC

I need to test the setup on my PC so the nginx configuration will be different on the PC. I need separate configurations for host and server

In the *deploy/nginx/configs/host/* directory, create a file named *nginx.conf* and add the following to it:

```
server {
    listen 80;
    server_tokens off;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_tokens off;
    ssl_certificate /etc/nginx/certs/cert.pem;
    ssl_certificate_key /etc/nginx/certs/key.pem;
    location / {
        proxy_pass http://127.0.0.1:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Protocol $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        
    }
}
```

Next, to support eventual deployment to a real server connected to the Intenet, create the *nginx.conf* file in the *deploy/nginx/configs/server/* directory. The main difference between the two files is the URLs in the *server_name* field and the SSL certificates.

```
server {
    listen 80;
    server_name musicfestivalorganizer.com *.musicfestivalorganizer.com;
    server_tokens off;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name musicfestivalorganizer.com;
    server_tokens off;
    
    ssl_certificate /etc/nginx/certs/cert.pem;
    ssl_certificate_key /etc/nginx/certs/key.pem;

    location / {
        proxy_pass http://app:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Protocol $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    }
}
```

### Create certificates SSL

In *deploy/nginx/certs/host/* run the following command

```
ssh-keygen -t rsa -b 4096 -m PEM
```

When asked where to store the key, put it in the *deploy/nginx/certs/host/* directory by entering in the full path with filename which, in my case, is: `/home/blinklet/Projects/Music Festival Program/music-festival-organizer/deploy/nginx/certs/host/key.pem`.

This results in two files being created: *key.pem* AND *key.pem.pub*.

Then, create the cert

```
openssl req -new -x509 -key key.pem -out cert.pem -days 100
```

The private key is *key.pem* and the certificate is *cert.pem*. So those are the files to use as the certificate and the key that signs the certificate

And, of course, add the private key and certificate files to your *.gitignore* file:

```
# certificate files
*.pem
*.pub
```

### Fix development.env

Now that we plan to have everything running in docker containers and on separate docker networks, the "localhost" address in the sqlalchemy database URI in the *production.env* file will not work. I need to address the database container directly.

It's the same for the Redis URI.

Change the two lines in the *production.env* file so they are:

```
# /production.env

# ...
SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://postgres:fake-password@db:5432/postgres"
# ...
REDIS_URL = "redis://cache:6379"
# ...
```

Then, rebuild the application container

```
docker stop app
docker container rm app
docker image rm mfo-app
docker build \
    --tag mfo-app \
    --file ./deploy/app/dockerfile \
    .
```
### Test NGINX server

To test system with the NGINX container, create Docker networks so we can replicate how this will be set up on a server

```
docker network create --internal backend_network
docker network create --internal frontend_network
docker network create external_network
```

Then, start the application, database, and cache containers:

```
docker run --detach \
    --name app \
    --network=bridge \
    --volume=./mfo:/mfo-app/mfo:ro \
    --volume=./tests:/mfo-app/tests:ro \
    --volume=./production.env:/mfo-app/production.env:ro \
    mfo-app

docker run --detach \
    --name db \
    --env POSTGRES_USER=postgres \
    --env POSTGRES_PASSWORD=fake-password \
    --env POSTGRES_DB=postgres \
    --network=backend_network \
    postgres

docker run --detach \
    --name cache \
    --network=backend_network \
    redis
    
docker exec app flask database create
docker exec app flask database test_users
```

To test the server, mount the *deploy/nginx/configs/host* and *deploy/nginx/certs/host* directories to the NGINX docker volume when you start the NGINX container. Use the official NGINX container from docker hub.

Docker requires the full pathname of the mounted volumes so your volume paths will likely be different than mine...

```
docker run --detach \
    --name nginx \
    --network frontend_network \
    --network external_network \
    --publish 80:80 \
    --publish 443:443 \
    --volume "/home/blinklet/Projects/Music Festival Program/music-festival-organizer/deploy/nginx/configs/host":/etc/nginx/conf.d:ro \
    --volume "/home/blinklet/Projects/Music Festival Program/music-festival-organizer/deploy/nginx/certs/host":/etc/nginx/certs:ro \
    nginx
```

Then, enter the following URL into the browser search bar:

```
http://localhost
```

You might get a warning page about invalid certs, because I signed my own cert and I am not a certificate authority. Click through the warnings and the application page will appear.

# Set up a URL

Create a DNS entry in my hosts folder so I can address my test app using a domain name.

```
sudo nano /etc/hosts
```

Add the following to the file:

```
127.0.0.1 local.musicfestivalorganizer.com
```

Now, when you enter *local.musicfestivalorganizer.com* in your browser search bar, you get directed to the NGINX container running at 127.0.0.1.

If you get directed to the registrar where you registered the domain, you may need to clear your browser cache and restart the browser.

Now, shut down the web app and delete the containers and networks.

```
docker stop db cache app nginx
docker container prune
docker network rm backend_network external_network frontend_network
```

# Create a Docker Compose file

Now that I tested this system, I need to create a way to manage these four containers. There are many Docker orchestration systems around but I will use Docker Compose.

In the project directory, create a Docker Compose file that describes the system:

```
name: mfo

services:
  app:
    image: mfo-app
    networks:
      - frontend_network
      - backend_network
    volumes:
      - type: bind
        source: ./mfo
        target: /mfo-app/mfo
        read_only: true
      - type: bind
        source: ./tests
        target: /mfo-app/tests
        read_only: true
      - type: bind
        source: ./production.env
        target: /mfo-app/production.env
        read_only: true
    depends_on:
      - db
      - cache

  db:
    image: postgres
    environment:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: fake-password
      POSTGRES_DB: postgres
    volumes:
      - type: volume
        source: mfo-data
        target: /var/lib/postgresql/data
    networks:
      - backend_network

  cache:
    image: redis
    networks:
      - backend_network

  nginx:
    image: nginx
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - type: bind
        source: ./deploy/nginx/configs/host
        target: /etc/nginx/conf.d
        read_only: true
      - type: bind
        source: ./deploy/nginx/certs/host
        target: /etc/nginx/certs
        read_only: true
    networks:
      - frontend_network
      - external_network
    depends_on:
      - app

networks:
  backend_network:
    driver: bridge
    internal: true
  frontend_network:
    driver: bridge
    internal: true
  external_network:
    driver: bridge

volumes:
  mfo-data:
```

## test the compose file

Test that docker compose is configured correctly by running the followig command:

```
docker compose up --detach
```

This should start all four containers. The container names will be different than before because docker compose uses the project name, "mfo" and adds a suffix to each container name

Then, initialize the database by running the Flask CLI commands:

```
$ docker exec mfo-app-1 flask database create
$ docker exec mfo-app-1 flask database test_users
```

You can see the application works the same as before

To stop the system, use the command

```
docker compose stop
```

This stops the four containers but leaves the system resources, such as networks and volumes, intact.

You can start the system again with the command:

```
docker compose up
```

If you want to clean up everything, run the command:

```
docker compose down
```

This command deletes the containers, networks, and volumes.


# Create a VPS

Now, deploy the code to an actual server in the cloud so users can access it. Configure the cloud server so it uses the same services as your development-test environment

You can use any cloud provider like Amazon AWS, [Akamai](), DigitalOcean, etc... I am using Microsoft Azure because I am familiar with it and it has a rich command-line interface.

We use the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest) in this post because it is easier to write examples using Azure CLI text commands than to create and annotate dozens of screenshots from the Azure Portal graphical user interface. However, all the procedures listed below may also be executed using the Azure Portal GUI.

## Security

The following best practices will help ensure security while you work to develop your lab.

1) The *root* account on an Azure Infrastructure VM is disabled by default. Do not enable it. Use the *sudo* command to run processes with root privileges.
2) Use an SSH key pair for your *admin* account authentication. Don't use a password.
3) Configure the VM's network security group to block all incoming connections, except connections from your own, and your clients' IP addresses.
4) If you VM running all the time, use [Just in Time](https://docs.microsoft.com/en-us/azure/security-center/security-center-just-in-time) (JIT) security to automatically enable and disable SSH access during the times when you need to use the VM. This reduces the duration during which the VM's SSH port is exposed. 
    * Or, manually disable SSH access by deleting the inbound SSH rule from your VM's network security group when you stop using it. Add the rule back when you start administering the VM again.
    

## Connect to Azure CLI

Connect to the [Azure CLI](hhttps://learn.microsoft.com/en-us/cli/azure/?view=azure-cli-latest) at: https://shell.azure.com. Select the *Bash Shell*.

Alternatively, you may [install the Azure CLI command on your PC](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux).

## VPS elements

A simple VPS in Azure consists of one [Azure VM](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-cli) with one public IP address, one interface, and one firewall (also called a Network Security Group).

## VPS image

Azure VPS starts from an [operating system image]((https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage)). You need to find the image you want to run.

To list all available Ubuntu images in the Azure Marketplace, at the East US region, where I am planning to run my VM, run the following command:

```
az vm image list-skus -l eastus -f ubuntu -p Canonical --output table
```

This will generate a long list of CentOS images. Assuming you know what the current release of Ubuntu is -- and in this example, it is Release 24.04 -- you may narrow down the list of images with the following command:

```
az vm image list \
    --offer Ubuntu \
    --publisher Canonical \
    --location canadacentral \
    --output table
```

From that output, get the [Ubuntu 24.04 image](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts). Get the image's URN Alias like: `Ubuntu2404`

```
Architecture    Offer                         Publisher    Sku             Urn                                                           UrnAlias       Version
--------------  ----------------------------  -----------  --------------  ------------------------------------------------------------  -------------  ---------
x64             0001-com-ubuntu-server-jammy  Canonical    22_04-lts-gen2  Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest  Ubuntu2204     latest
x64             ubuntu-24_04-lts              Canonical    server          Canonical:ubuntu-24_04-lts:server:latest                      Ubuntu2404     latest
x64             ubuntu-24_04-lts              Canonical    ubuntu-pro      Canonical:ubuntu-24_04-lts:ubuntu-pro:latest                  Ubuntu2404Pro  latest

```

Or, look at the [Ubuntu docs](https://documentation.ubuntu.com/azure/en/latest/azure-how-to/instances/find-ubuntu-images/) to get the latest URN for its Azure image.

## Get VM size

https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview


```
az vm list-sizes --location canadacentral
```

## SSH key

See: External-SSH-HOWTO.pptx

The simplest way to use SSH is to run the `ssh-keygen` command on the same Linux system -- either Azure Shell or Windows Subsystem for Linux -- you use to start and access the VM. The `ssh-keygen` command saves, by default, the public and private keys, *id_rsa.pub* and *id_rsa* in OpenSSH format in the default directory, *~/.ssh*. Then you may use the Azure CLI  *--generate-ssh-keys* option when starting a VM, which will copy your public SSH key to the VM you create. 

## Get your IP address

Go to [https://google.com](https://google.com) and type in the search query, "What is my IP address?". Google will show you your IP address. This is the value you will use to configure your firewall.

In this example, my IP address is:

```
    24.212.163.244
```

## Login to Azure CLI

To create the virtual machine, first, login to the Azure CLI (note that you are already logged in if you are using the Azure CLoud Shell).

```
az login
```

## Create VPS

https://azure.microsoft.com/en-ca/pricing/details/virtual-machines/linux/#pricing

We assume you have already generated your SSH keys. If you did not, the Azure CLI `--generate-ssh-keys` option will create them for you in the default *~/.ssh* folder with the default names, *id_rsa* and *id_rsa.pub*.

Create resource group.

```
az account set -s "Azure subscription 1"
az group create --name test-group --location canadacentral
```

The Azure CLI command to create 

```
az vm create \
    --resource-group test-group \
    --name test-vm \
    --location canadacentral \
    --size Standard_B1s \
    --storage-sku StandardSSD_LRS \
    --admin-username fadmin \
    --generate-ssh-keys \
    --image Ubuntu2404
```

From the response, you can see the VM's public IP address:

```
{
  "fqdns": "",
  "id": "/subscriptions/e0892a48-576e-4aa9-a2d3-b7490707ccfb/resourceGroups/test-group/providers/Microsoft.Compute/virtualMachines/test-vm",
  "location": "canadacentral",
  "macAddress": "00-0D-3A-E9-2A-4B",
  "powerState": "VM running",
  "privateIpAddress": "10.0.0.4",
  "publicIpAddress": "4.204.61.164",
  "resourceGroup": "test-group",
  "zones": ""
}
```

## Firewall

You need to modify the default SSH access rule to restrict inbound connections to only those that come from your PC. The command to modify the default SSH rule named *default-allow-ssh* is shown below.

```
az network nsg rule update \
    --resource-group test-group \
    --nsg-name test-vmNSG \
    --name default-allow-ssh \
    --protocol tcp \
    --direction inbound \
    --source-address-prefix 24.212.163.244/32
```

Test that you can access the VM:

```
ssh fadmin@4.204.61.164
```

If you log in successfully, it works. Then exit the VM.

Add rules to add HTTP and HTTPS to the allowed inbound ports, but only from my IP address


```
az network nsg rule create \
    --resource-group test-group \
    --nsg-name test-vmNSG \
    --name allow-web \
    --protocol tcp \
    --direction inbound \
    --source-address-prefixes 24.212.163.244/32 \
    --source-port-ranges '*' \
    --destination-address-prefixes '*' \
    --destination-port-ranges 443 80 \
    --access allow \
    --priority 1100
```

## Access the VM

First, you need to get public IP address of the lab VM.

The following Azure CLI command will display the IP address of the VM:

```
az network public-ip show \
    --resource-group test-group \
    --name test-vmPublicIP \
    --query "ipAddress" \
    --output tsv
```
```
4.204.61.164
```




The use SSH to access the VM

```
ssh fadmin@4.204.61.164
```

or 

```
ssh -i ~/.ssh/id_rsa fadmin@4.204.61.164
```

## Set up VM

Need to install docker and docker compose.

```
sudo apt update
sudo apt upgrade
sudo snap install docker
sudo groupadd docker
sudo usermod -aG docker $USER
newgrp docker
sudo reboot
```

Connect to the VM again and test docker:

```
docker run hello-world
```

## Create Docker Compose for VM

Edit the current docker-compose.yml file change the "image" command to "build" in the *app* service. This will allow docker compose to automatically build the *mfo-app* image using its dockerfile

```
services:
  app:
    build:
      context: .
      dockerfile: deploy/app/dockerfile
    volumes:
      - type: bind
        source: ./mfo
        target: /mfo-app/mfo
        read_only: true
      - type: bind
        source: ./tests
        target: /mfo-app/tests
        read_only: true
      - type: bind
        source: ./production.env
        target: /mfo-app/production.env
        read_only: true
    networks:
      - frontend_network
      - backend_network
    depends_on:
      - db
      - cache
```

## Copy files to the VM

From local PC, copy the necessary files from the *music-festival-organize* project directory to the VM's */home/fadmin/* directory

```
cd music-festival-organizer
scp -r ./mfo fadmin@4.204.61.164:~/mfo
scp -r ./tests fadmin@4.204.61.164:~/tests
scp -r ./deploy fadmin@4.204.61.164:~/deploy
scp ./production.env fadmin@4.204.61.164:~/
scp ./requirements-prod.txt fadmin@4.204.61.164:~/
scp ./docker-compose.yml fadmin@4.204.61.164:~/
```

Then, connect to VM and run *docker compose up*

```
docker compose up --detach
docker exec mfo-app-1 flask database create
docker exec mfo-app-1 flask database test_users
```

```
http://4.204.61.164
```

# VM Size

Performance was bad. App froze. Terminal froze. Clearly, the VM is too small

Stop the VM: 

```
az vm deallocate --resource-group test-group --name test-vm
```

Resize the VM. I will try the *B2S* size that has 4 GB of RAM. But, it costs $30 per month or $240 per year.

```
az vm resize --resource-group test-group --name test-vm --size Standard_B2s
```

Start the VM

```
az vm start --resource-group test-group --name test-vm
```

Find the new IP address because it may have changed when you re-sized the VM


```
az network public-ip show -g test-group -n test-vmPublicIP --query "ipAddress" -o tsv
```
```
4.204.61.164
```

log in and start the app

```
ssh fadmin@4.204.61.164
```

Test again. 

```
https://4.204.61.164
```

So... 2vCPU and 4 GB RAM seem to be enough for the app to run as well as it did on my laptop computer,

# Stop the app

On the test-vm VM, stop the app:

```
docker compose down
```

And, from my laptop, stop the VM (to save money):

```
az vm deallocate --resource-group test-group --name test-vm
```

### Costs

Storage cost is ongoing, VM only when running

Container registry is expensive so I will copy my own container to the server, or build it locally on the server.

Azure B2s VM costs C$30 per month for 2 vCPUs and 4GB RAM. The disk attached to it costs an additional C$4 per month.

DigitalOcean and Akamai both offer a similar VM size for US$24 per month so they are similar in cost. But, they also offer smaller VMs that might have enough memory for US$12 per month. In the future, I will investigate these offerings and other, cheaper, offerings available in Canada from VPS companies like [OVH](https://www.ovhcloud.com/en-ca/), [VPSServer](https://www.vpsserver.com/plans/), [Dedicated Core](https://www.dedicatedcore.com/vps-hosting/canada/), or [inet](https://inet.ws/).

Other low-cost offerings available in the USA or Europe are: [Hetzner](https://www.hetzner.com/cloud/), [IONOS](https://www.ionos.ca/), 

> An option to maybe lower the hosting cost is to runmy development environment on a VPS. If I eliminate the overhead required to run Docker, Postgres, and Redis, maybe I can run everything in 1 GB of RAM. In that scenario, I would install NGINX directly on the VPS, set up a Python virtual environment for my app, use SQLite for the database and the filesystem for caching session data. It would probably work well enough for a few users and that's all I need right now.





# Create certificate for my domain

## Set up DNS record

At your domain provider's web site, configure DNS setings to point your domain to the Azure VPS public IP

I use [Hover](https://support.hover.com/support/solutions/articles/201000064728-managing-dns-records) so I:

* Select *Domains* in Hover's control panel
* Click the the domain name
* Click the *DNS* link in the navigation bar above the domain overview page
* There should be two "A" records. Click *Edit* link next to each and replace the IP address with my VPS public IP
* Then wait 15 minutes for changes to propagate

## Get cert


I've been using a self-signed cert for testing. Now that I want to deploy this to my client, I need to get a certificate that is signed by a Certificate Authority.

For a secure HTTPS setup, you’ll need to acquire SSL certificates for your domain. You can use **Certbot** or get the SSL certificates manually from your preferred provider. Place the certificates (`cert.pem` and `key.pem`) in the `/certs` directory.

If you’re using Certbot, you can install it on your VPS, run the following command, and follow the prompts to get SSL certificates for your domain:

When getting a certificate, certbot needs to be able to communicate with its server and the server needs to be able to challenge the website. So, I need to temporarily allow all IP addresses to connect to ports 80 and 443

```
az network nsg rule update \
  --resource-group test-group \
  --nsg-name test-vmNSG \
  --name allow-web \
  --access Allow \
  --protocol Tcp \
  --direction Inbound \
  --priority 1100 \
  --source-address-prefixes '*' \
  --destination-port-ranges 80 443
```

az network nsg rule list --resource-group test-group --nsg-name test-vmNSG --output table

On the VPS: 

```bash
sudo apt install certbot
docker compose down
sudo certbot certonly \
    --standalone \
    -d musicfestivalorganizer.com \
    -d www.musicfestivalorganizer.com
```

From the command output, we can see that the certs were saved to */etc/letsencrypt/live/musicfestivalorganizer.com/* on the VPS. 

I could copy them to *./deploy/nginx/configs/host*, but to take advantage of certbot's automatic renewals, I should probably update the docker compose file to bind the */etc/letsencrypt/live/musicfestivalorganizer.com/* folder on teh VPS to */etc/nginx/certs* on the nginx container.

Also, point to the sever nginx.config file

Change *docker-compose.yml* so it's NGINX sevice looks like below:

```
  nginx:
    image: nginx
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - type: bind
        source: ./deploy/nginx/configs/server
        target: /etc/nginx/conf.d
        read_only: true
      - type: bind
        source: /etc/letsencrypt
        target: /etc/nginx/certs
        read_only: true
    networks:
      - frontend_network
      - external_network
    depends_on:
      - app
```

And change the NGINX server config file so it points to teh correct keys

```
server {
    listen 80;
    server_name musicfestivalorganizer.com *.musicfestivalorganizer.com;
    server_tokens off;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name musicfestivalorganizer.com;
    server_tokens off;
    
    ssl_certificate /etc/nginx/certs/live/musicfestivalorganizer.com/fullchain.pem
    ssl_certificate_key /etc/nginx/certs/live/musicfestivalorganizer.com/privkey.pem;

    location / {
        proxy_pass http://127.0.0.1:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Protocol $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    }
}
```

Upload the files to the VPS

```
scp ./docker-compose.yml fadmin@4.204.61.164:~/
scp -r ./deploy/nginx/configs/server/nginx.conf \
    fadmin@4.204.61.164:~/deploy/nginx/configs/server/nginx.conf
```

```
docker compose up
```

Results in error:
```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /etc/letsencrypt
```

This seems to be a permissions issue. I tried

```
sudo chmod 0755 /etc/letsencrypt/{live,archive}
```

But still the same issue. The workaround, for now, is to just copy the certs to a normal directory like *./deploy/nginx/certs/server/* on the VPS and change the docker-compose.yml and nginx.config files as follows:

```
  nginx:
    image: nginx
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - type: bind
        source: ./deploy/nginx/configs/server
        target: /etc/nginx/conf.d
        read_only: true
      - type: bind
        source: ./deploy/nginx/certs/server
        target: /etc/nginx/certs
        read_only: true
    networks:
      - frontend_network
      - external_network
    depends_on:
      - app
```

```
server {
    listen 80;
    server_name musicfestivalorganizer.com *.musicfestivalorganizer.com;
    server_tokens off;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name musicfestivalorganizer.com;
    server_tokens off;
    
    ssl_certificate /etc/nginx/certs/fullchain.pem;
    ssl_certificate_key /etc/nginx/certs/privkey.pem;

    location / {
        proxy_pass http://app:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Protocol $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    }
}
```

```
scp ./docker-compose.yml fadmin@4.204.61.164:~/
scp -r ./deploy/nginx/configs/server/nginx.conf \
    fadmin@4.204.61.164:~/deploy/nginx/configs/server/nginx.conf
```

And then, on the VPS:

```
docker compose up
```

Test the web site,. It works!

### **Final Notes:**

- **Database configuration:** I need to secure and manage my Postgres database credentials carefully. I will consider using Docker secrets or environment variables for more secure setups.
- **SSL Renewal:** Set up a Cron job to automatically copy the renewed SSL certificates to the correct folder
- **Docker permission issues** I could not mount the directory */etc/certbot* to a docker volume. Could this be because I installed Docker with the snap? What if I use the "native" docker install usinf apt?


### Lightweight deployment

Following up from my note about costs, I decided to try to run a simple setup with Nginx, Python, and SQLite on a VPS.

So, I created a new environment named "lightweight"

I created a *lightweight.env* file and modified *config.py* to add a check for the new environment.

lightweight.env

```
# ./lightweight.env

FLASK_ENVIRONMENT = lightweight
# Generate a key using "secrets.token_urlsafe()"
FLASK_SECRET_KEY = LGBoUEDCCpgwxy5jZxpu9e01MTnRVqnG6A8ceD7Z4YU
FLASK_EXPLAIN_TEMPLATE_LOADING = False

# Flask-SQLAlchemy variables
# --------------------------
SQLALCHEMY_DATABASE_URI = ""
SQLALCHEMY_ECHO = False

# Flask-Session variables
# -----------------------
SESSION_TYPE = "filesystem"
SESSION_THRESHOLD = 50
PERMANENT_SESSION_LIFETIME = 1209600

# Flask-Security variables
# ------------------------
# generate a salt using "secrets.SystemRandom().getrandbits(128)"
SECURITY_PASSWORD_SALT  = 307680677384259925768439955171685999662

# command line variables
# ----------------------
TEST_USERS_FILE = "tests/test_users.json"
```

config.py

```
# ...

# Flask-SQLAlchemy variables
if ENVIRONMENT == "development" or ENVIRONMENT == "lightweight":
    # For development, use a SQLite database located in the project folder
    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(project_dir, 'app.sqlite')
else:
    # For production, get the database URI from environment variable
    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
    
# ...

if ENVIRONMENT == "development" or ENVIRONMENT == "lightweight":
    TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
    TEST_USERS_FILE = os.path.join(project_dir, TEST_USERS_FILE)
else:
    TEST_USERS_FILE = os.environ.get("TEST_USERS_FILE")
```

Then, I start a B1s VPS on Azure, which has 1 vCPU and 1G of memory and was too small to run my app with Dockeer, Postgres, and Redis.
I re-use the test-vmNSG so I don't have to configure networking

```
az vm create \
    --resource-group test-group \
    --name light-vm \
    --location canadacentral \
    --size Standard_B1s \
    --storage-sku StandardSSD_LRS \
    --admin-username fadmin \
    --generate-ssh-keys \
    --nsg test-vmNSG \
    --image Ubuntu2404
```

Log into the VPS

```
ssh fadmin@4.206.103.213
```

Then install nginx and certbot

on VPS: 

```
sudo apt update
sudo apt upgrade
sudo apt install nginx
sudo apt install default-jre
sudo apt install python3.12-venv
```

For now, just copy the private keys. We'll use certbot to get "proper" keys later, if this works

On local PC:

```
cd music-festival-organizer
scp -r ./mfo fadmin@4.206.103.213:~/mfo
scp -r ./tests fadmin@4.206.103.213:~/tests
scp -r  ./deploy/nginx/configs/host fadmin@4.206.103.213:~/configs  
scp -r ./deploy/nginx/certs/host fadmin@4.206.103.213:~/certs
scp ./lightweight.env fadmin@4.206.103.213:~/
scp ./requirements.txt fadmin@4.206.103.213:~/
```

Then, connect to VM and run the app

```
sudo cp ~/configs/nginx.conf /etc/nginx/conf.d/
sudo mkdir -p /etc/nginx/certs
sudo cp ~/certs/* /etc/nginx/certs
export FLASK_ENV=lightweight
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
pip install gunicorn
flask --app mfo.app database create
flask --app mfo.app database test_users
gunicorn -w 4 -b 0.0.0.0:8000 mfo.wsgi:app
```

Modified the nginx.conf file on the server. Changed the address to 127.0.0.1 and commented out the server names.

```
server {
    listen 80;
    # server_name local.musicfestivalorganizer.com;
    server_tokens off;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    # server_name local.musicfestivalorganizer.com;
    server_tokens off;
    ssl_certificate /etc/nginx/certs/cert.pem;
    ssl_certificate_key /etc/nginx/certs/key.pem;
    location / {
        proxy_pass http://127.0.0.1:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Protocol $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        
    }
}
```

Then in browser:

```
http://4.204.61.164
```

Web site works! But workers timeout when I try to import the syllabus or do any operation that requires the database. If I increase the worker timeout as follows:

```
gunicorn -w 4 -b 0.0.0.0:8000 --timeout 240 mfo.wsgi:app
```

The Syllabus upload works but then the spreadsheet upload fails and the server completely hangs. It does not seem to matter how long I set the timeout. I suspect memory is exhausted.

So, looks like I still need at least 2 GB on the server.