### PR TITLE
Eager loading of repertoire relationships

### DIFF
--- a/mfo/admin/views.py
+++ b/mfo/admin/views.py
@@ -305,7 +305,11 @@ def edit_class_info_post():
 def repertoire_get():
     sort_by = flask.request.args.getlist('sort_by')
     sort_order = flask.request.args.getlist('sort_order')
-    stmt = select(Repertoire)
+    stmt = select(Repertoire).options(
+        selectinload(Repertoire.festival_classes).load_only(FestivalClass.id),
+        selectinload(Repertoire.used_in_entries).load_only(Entry.id)
+    )
+
     repertoire = db.session.execute(stmt).scalars().all()
 
     repertoire_list = admin_services.get_repertoire_list(


### PR DESCRIPTION
Added *selectinload* options to repertoire relationships. Also load only IDs from _FestivalClass_ and _Entry_ tables because I am only counting the number of each item related to the repertoire row.

```
    stmt = select(Repertoire).options(
        selectinload(Repertoire.festival_classes).load_only(FestivalClass.id),
        selectinload(Repertoire.used_in_entries).load_only(Entry.id)
    )
```

