### PR TITLE
79 classes report rows per page

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -99,7 +99,7 @@ class ClassSortForm(FlaskForm):
     # these name of each label must match the key in the _classes dictionary
     field_choices = [
         ("none", ""),
-        ("number", "Class Number"),
+        ("number_suffix", "Class Number"),
         ("name", "Name"),
         ("discipline", "Discipline"),
         ("class_type", "Type"),
@@ -115,15 +115,15 @@ class ClassSortForm(FlaskForm):
     ]
 
     page_choices = [
-        ("short", "10"),
-        ("medium", "20"),
-        ("long", "50"),
-        ("all", "All"),
+        ("10", "10"),
+        ("20", "20"),
+        ("50", "50"),
+        ("100000", "All"),
     ]
 
     reset = SubmitField('Reset')
     submit = SubmitField('Sort')
-
+    page_rows = SelectField('Displayed rows:', choices=page_choices, validators=[InputRequired()])
 
     sort1 = SelectField('Sort by:', choices=field_choices, validators=[Optional()])
     order1 = SelectField('Order:', choices=order_choices, validators=[Optional()])

--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -1,3 +1,5 @@
+# mfo/admin/forms.py
+
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileRequired
 from wtforms import ValidationError, StringField, SubmitField, HiddenField, IntegerField, DecimalField, SelectField, TextAreaField, PasswordField
@@ -97,10 +99,10 @@ class ClassSortForm(FlaskForm):
     # these name of each label must match the key in the _classes dictionary
     field_choices = [
         ("none", ""),
-        ("number_suffix", "Class Number"),
+        ("number", "Class Number"),
         ("name", "Name"),
         ("discipline", "Discipline"),
-        ("type", "Type"),
+        ("class_type", "Type"),
         ("number_of_entries", "Entries"),
         ("total_fees", "Total fees"),
         ("total_time", "Total time"),

--- a/mfo/admin/services/admin_services.py
+++ b/mfo/admin/services/admin_services.py
@@ -126,7 +126,7 @@ def get_class_list(classes, sort_by=None, sort_order=None):
         }
         class_list.append(class_dict)
 
-    return sort_list(class_list, sort_by, sort_order)
+    return class_list
 
 
 def get_repertoire_list(repertoire, sort_by=None, sort_order=None):

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -40,3 +40,53 @@
         {% endfor %}
     </tbody>
 </table>
+
+<div class="d-flex justify-content-center align-items-center mt-4 mb-4">
+    <nav>
+        <ul class="pagination mb-0">
+            <li class="page-item {% if page == 1 %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=page-1, per_page=per_page) }}">
+                    <span>&laquo;</span>
+                </a>
+            </li>
+            {% set total_pages = (total_classes // per_page) + 1 %}
+            {% if total_pages > 1 %}
+                {% if page > 3 %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=1, per_page=per_page) }}">1</a>
+                    </li>
+                    {% if page > 4 %}
+                        <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% endif %}
+                {% endif %}
+                {% for p in range([1, page-2]|max, [total_pages, page+2]|min + 1) %}
+                    <li class="page-item {% if p == page %}active{% endif %}">
+                        <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=p, per_page=per_page) }}">{{ p }}</a>
+                    </li>
+                {% endfor %}
+                {% if page < total_pages - 2 %}
+                    {% if page < total_pages - 3 %}
+                        <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% endif %}
+                    <li class="page-item">
+                        <a class="page-link" 
+                        href="{{ url_for('admin.classes_get', 
+                        sort_by=sort_by, sort_order=sort_order, 
+                        page=total_pages, per_page=per_page) }}">
+                            {{ total_pages }}
+                        </a>
+                    </li>
+                {% endif %}
+            {% endif %}
+            <li class="page-item {% if page == total_pages %}disabled{% endif %}">
+                <a class="page-link" 
+                href="{{ url_for('admin.classes_get', 
+                sort_by=sort_by, sort_order=sort_order, 
+                page=page+1, per_page=per_page) }}">
+                    <span>&raquo;</span>
+                </a>
+            </li>
+        </ul>
+
+    </nav>
+</div>

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -31,9 +31,9 @@
             <td><a href="{{ url_for('admin.class_info_get', id=_class.id) }}">{{ _class.number_suffix }}</a></td>
             <td>{{ _class.name }}</td>
             <td>{{ _class.discipline }}</td>
-            <td>{{ _class.type }}</td>
+            <td>{{ _class.class_type }}</td>
             <td class="text-end">{{ _class.number_of_entries }}</td>
-            <td class="text-end">{{ _class.total_fees }}</td>
+            <td class="text-end">${{ '%.2f' | format(_class.total_fees) }}</td>
             <td class="text-end">{{ format_time(_class.total_time, show_seconds=False) }}</td>
         </tr>
         

--- a/mfo/admin/templates/admin/partials/sort_classes_form.html
+++ b/mfo/admin/templates/admin/partials/sort_classes_form.html
@@ -1,3 +1,5 @@
+<!-- mfo/admin/templates/admin/partials/sort_classes_form.html -->
+
 <div class="row d-flex justify-content-center pt-3 pb-4">
     <div col-md-6>
         <form method="post" action="{{ url_for('admin.classes_post') }}">
@@ -42,6 +44,14 @@
                 </div>
                 <div class="col-md-2">
                     {{ form.order3(class="form-select") }}
+                </div>
+            </div>
+            <div class="row mb-3 align-items-center d-flex justify-content-center">
+                <div class="col-md-3 text-end">
+                    {{ form.page_rows.label(class="form-label") }}
+                </div>
+                <div class="col-md-2">
+                    {{ form.page_rows(class="form-select") }}
                 </div>
             </div>
             <div class="row align-items-center d-flex justify-content-center">

--- a/mfo/admin/views.py
+++ b/mfo/admin/views.py
@@ -217,7 +217,8 @@ def classes_get():
         form.sort1.data = 'number_suffix'
         form.order1.data = 'asc'
 
-    subquery_entries = (
+
+    class_entries = (
         select(
             Entry.class_id,
             func.count(Entry.id).label('number_of_entries')
@@ -225,81 +226,47 @@ def classes_get():
         .group_by(Entry.class_id)
     ).subquery()
 
-    subquery_duration = (
-        select(
-            Entry.class_id,
-            func.sum(Repertoire.duration).label('total_repertoire_duration')
-        )
-        .join(entry_repertoire, entry_repertoire.c.entry_id == Entry.id)
-        .join(Repertoire, Repertoire.id == entry_repertoire.c.repertoire_id)
-        .group_by(Entry.class_id)
-    ).subquery()
-        
     stmt = (
         select(
-            # FestivalClass,
+            FestivalClass.id.label('id'),
             func.concat(FestivalClass.number, FestivalClass.suffix).label('number_suffix'),
-            (FestivalClass.name).label('name'),
+            FestivalClass.name.label('name'),
             FestivalClass.discipline.label('discipline'),
             FestivalClass.class_type.label('class_type'),
-            subquery_entries.c.number_of_entries,
-            (FestivalClass.fee * subquery_entries.c.number_of_entries).label('total_fees'),
-            (subquery_duration.c.total_repertoire_duration +
-                (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
-                (subquery_entries.c.number_of_entries * FestivalClass.move_time)
+            class_entries.c.number_of_entries,
+            (FestivalClass.fee * class_entries.c.number_of_entries).label('total_fees'),
+            (func.sum(Repertoire.duration) +
+                (FestivalClass.adjudication_time * class_entries.c.number_of_entries) +
+                (FestivalClass.move_time * class_entries.c.number_of_entries)
             ).label('total_time')
         )
-        .outerjoin(subquery_entries, subquery_entries.c.class_id == FestivalClass.id)
-        .outerjoin(subquery_duration, subquery_duration.c.class_id == FestivalClass.id)
-        .join(Entry, Entry.class_id == FestivalClass.id)  # Ensure Entry is joined
-        .group_by(FestivalClass.id, subquery_entries.c.number_of_entries)
+        .join(FestivalClass.entries)
+        .join(Entry.repertoire)
+        .join(class_entries, FestivalClass.id == class_entries.c.class_id)
+        .group_by(
+            FestivalClass.id,
+            FestivalClass.number,
+            FestivalClass.suffix,
+            FestivalClass.name,
+            FestivalClass.discipline,
+            FestivalClass.class_type,
+            FestivalClass.fee,
+            class_entries.c.number_of_entries,
+        )
         .having(func.count(Entry.id) > 0)
-        # .options(
-        #     selectinload(FestivalClass.entries).selectinload(Entry.repertoire)
-        # )
     )
 
     if sort_by and sort_order:
         for column, order in zip(sort_by, sort_order):
-            if column == 'number_of_entries':
-                if order == 'asc':
-                    stmt = stmt.order_by(asc(subquery_entries.c.number_of_entries))
-                elif order == 'desc':
-                    stmt = stmt.order_by(desc(subquery_entries.c.number_of_entries))
-            elif column == 'total_fees':
-                if order == 'asc':
-                    stmt = stmt.order_by(asc(FestivalClass.fee * subquery_entries.c.number_of_entries))
-                elif order == 'desc':
-                    stmt = stmt.order_by(desc(FestivalClass.fee * subquery_entries.c.number_of_entries))
-            elif column == 'total_time':
-                if order == 'asc':
-                    stmt = stmt.order_by(asc(
-                        subquery_duration.c.total_repertoire_duration +
-                        (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
-                        (subquery_entries.c.number_of_entries * FestivalClass.move_time)
-                    ))
-                elif order == 'desc':
-                    stmt = stmt.order_by(desc(
-                        subquery_duration.c.total_repertoire_duration +
-                        (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
-                        (subquery_entries.c.number_of_entries * FestivalClass.move_time)
-                    ))
-            else:
-                if order == 'asc':
-                    stmt = stmt.order_by(asc(getattr(FestivalClass, column)))
-                elif order == 'desc':
-                    stmt = stmt.order_by(desc(getattr(FestivalClass, column)))
+            if order == 'asc':
+                stmt = stmt.order_by(asc(column))
+            elif order == 'desc':
+                stmt = stmt.order_by(desc(column))
 
 
     stmt = stmt.limit(per_page).offset((page - 1) * per_page)
 
     _classes = db.session.execute(stmt).all()
-    for x in _classes:
-        print(x)
-
-
-
-    # class_list = admin_services.get_class_list(_classes)
 
     return flask.render_template(
         'admin/class_report.html', 
@@ -308,6 +275,7 @@ def classes_get():
         page=page,
         per_page=per_page,
         )
+
 
 @bp.post('/report/classes')
 @flask_security.auth_required()

--- a/mfo/admin/views.py
+++ b/mfo/admin/views.py
@@ -207,6 +207,7 @@ def classes_get():
     page = int(flask.request.args.get('page', 1))
     per_page = int(flask.request.args.get('per_page', 10))
 
+
     # fill in form fields with sort_by and sort_order values
     if sort_by:
         sort_criteria = zip(sort_by, sort_order)
@@ -216,6 +217,8 @@ def classes_get():
     else:
         form.sort1.data = 'number_suffix'
         form.order1.data = 'asc'
+
+    form.page_rows.data = str(per_page) if per_page else '10'
 
 
     class_entries = (
@@ -251,6 +254,8 @@ def classes_get():
             FestivalClass.discipline,
             FestivalClass.class_type,
             FestivalClass.fee,
+            FestivalClass.adjudication_time,
+            FestivalClass.move_time,
             class_entries.c.number_of_entries,
         )
         .having(func.count(Entry.id) > 0)
@@ -267,13 +272,21 @@ def classes_get():
     stmt = stmt.limit(per_page).offset((page - 1) * per_page)
 
     _classes = db.session.execute(stmt).all()
+    
+    total_classes = db.session.execute(
+        select(func.count(FestivalClass.id))
+        .where(FestivalClass.entries.any())
+    ).scalar()
 
     return flask.render_template(
         'admin/class_report.html', 
+        sort_by=sort_by,
+        sort_order=sort_order,
         classes=_classes, 
         form=form,
         page=page,
         per_page=per_page,
+        total_classes=total_classes,
         )
 
 
@@ -295,8 +308,10 @@ def classes_post():
                 if sort_field != 'none': # 'none' is defined in the form's field_choice for no input
                     sort_by.append(sort_field)
                     sort_order.append(order_field)
+            per_page = form.page_rows.data
+            page = flask.request.args.get('page')
             # Display table with new sort_by and sort_order values
-            return flask.redirect(flask.url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order))
+            return flask.redirect(flask.url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=page, per_page=per_page))
     
 @bp.get('/info/class')
 @flask_security.auth_required()


### PR DESCRIPTION
# Add pagination to classes report

## The view functions

In the *classes_get()* view function, add a *limit(per_page)* method and an *offset(page)* method to the *select* statement. This also requires I have data for *page* and *per_page* that can be round-tripped via the route URL.

First, assume *page* and *per_page* are available as query parameters in the URL, set default values if they are not:

```
# mfo/admin/views.py
#...

    page = int(flask.request.args.get('page', 1))
    per_page = int(flask.request.args.get('per_page', 10))
    
# ...
```

Then, update the select statement by adding the *limit(per_page)* and *offset(page)* methods.

```
    stmt = (
        select(FestivalClass)
        .join(Entry, Entry.class_id == FestivalClass.id)
        .group_by(FestivalClass.id)
        .having(func.count(Entry.id) > 0)
        .options(
            selectinload(FestivalClass.entries).selectinload(Entry.repertoire)
        )
        .limit(per_page)
        .offset((page - 1) * per_page)
    )
```

And, finally, render the template with the *page* and *per_page* values in the context:

```
    return flask.render_template(
        'admin/class_report.html', 
        classes=class_list, 
        sort_by=sort_by, 
        sort_order=sort_order,
        form=form,
        page=page,
        per_page=per_page
    )
```

This revealed a problem!!

Now that I display only a portion of the results, when I sort the report it sorts only within the number of rows I specified per page. So I cannot, for example, sort by "Total Time" "Descending" and get the longest class in the database at the top of the list. I get only the first x rows sorted.

## Move sorting into the database query

So, I need to move the sorting into the database. Which means I need to do the calculation of Number/Suffix, Number of Entries, Total Fees, and Total Time in the database query.

This is a big change to the way I do sorting, but it is necessary to implement the pagination feature in a way that is useful.

This also means I need to refactor the field_choices in the form so they match the column names in the database. Looking in *mfo/database/models.py* I see the *FestivalClass* table columns are:

* id
* number
* suffix
* name
* class_type
* fee
* discipline
* adjudication_time
* move_time
* test_pieces (relationship)
* entries (relationship)

#### mfo/admin/forms.py

So change the *field_choices* list in the *ClassSortForm* form so they match the database columns.

For now, I will change the *number_suffix* field choice to *number*, although I hope to create a calculated column with *number_suffix* in the future. I will also change *type* to *class_type*

```
# mfo/admin/forms.py

class ClassSortForm(FlaskForm):
    # these name of each label must match the key in the _classes dictionary
    # and in the ClassSortForm database table columns
    field_choices = [
        ("none", ""),
        ("number", "Class Number"),
        ("name", "Name"),
        ("discipline", "Discipline"),
        ("class_type", "Type"),
        ("number_of_entries", "Entries"),
        ("total_fees", "Total fees"),
        ("total_time", "Total time"),
    ]
```

#### mfo/admin/views.py

Then, in the *classes_get()* view function, I add basic sorting to the query but I need to avoid sorting by calculated columns because they do not exist yet. I changed the *select* statement as shown below:

```
# mfo/admin/views.py
# ...

    stmt = (
        select(FestivalClass)
        .join(Entry, Entry.class_id == FestivalClass.id)
        .group_by(FestivalClass.id)
        .having(func.count(Entry.id) > 0)
        .options(
            selectinload(FestivalClass.entries).selectinload(Entry.repertoire)
        )
    )

    if sort_by and sort_order:
        for column, order in zip(sort_by, sort_order):
            if order == 'asc':
                stmt = stmt.order_by(asc(getattr(FestivalClass, column)))
            elif order == 'desc':
                stmt = stmt.order_by(desc(getattr(FestivalClass, column)))

    stmt = stmt.limit(per_page).offset((page - 1) * per_page)
    
# ...
```

This works, but will give an error if I sort by Total Time or Number of Entries, because those columns do not exist in the table.

To calculate the total_time and number of entries, I had to go off into a long journey of SQL discovery. I learned about subqueries

The query logic is now:

```
subquery_entries = (
        select(
            Entry.class_id,
            func.count(Entry.id).label('number_of_entries')
        )
        .group_by(Entry.class_id)
    ).subquery()

    subquery_duration = (
        select(
            Entry.class_id,
            func.sum(Repertoire.duration).label('total_repertoire_duration')
        )
        .join(entry_repertoire, entry_repertoire.c.entry_id == Entry.id)
        .join(Repertoire, Repertoire.id == entry_repertoire.c.repertoire_id)
        .group_by(Entry.class_id)
    ).subquery()
        
    stmt = (
        select(
            func.concat(FestivalClass.number, FestivalClass.suffix).label('number_suffix'),
            (FestivalClass.name).label('name'),
            FestivalClass.discipline.label('discipline'),
            FestivalClass.class_type.label('class_type'),
            subquery_entries.c.number_of_entries,
            (FestivalClass.fee * subquery_entries.c.number_of_entries).label('total_fees'),
            (subquery_duration.c.total_repertoire_duration +
                (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
                (subquery_entries.c.number_of_entries * FestivalClass.move_time)
            ).label('total_time')
        )
        .outerjoin(subquery_entries, subquery_entries.c.class_id == FestivalClass.id)
        .outerjoin(subquery_duration, subquery_duration.c.class_id == FestivalClass.id)
        .join(Entry, Entry.class_id == FestivalClass.id)  # Ensure Entry is joined
        .group_by(FestivalClass.id, subquery_entries.c.number_of_entries, subquery_duration.c.total_repertoire_duration)
        .having(func.count(Entry.id) > 0)
    )


    if sort_by and sort_order:
        for column, order in zip(sort_by, sort_order):
            if column == 'number_of_entries':
                if order == 'asc':
                    stmt = stmt.order_by(asc(subquery_entries.c.number_of_entries))
                elif order == 'desc':
                    stmt = stmt.order_by(desc(subquery_entries.c.number_of_entries))
            elif column == 'total_fees':
                if order == 'asc':
                    stmt = stmt.order_by(asc(FestivalClass.fee * subquery_entries.c.number_of_entries))
                elif order == 'desc':
                    stmt = stmt.order_by(desc(FestivalClass.fee * subquery_entries.c.number_of_entries))
            elif column == 'total_time':
                if order == 'asc':
                    stmt = stmt.order_by(asc(
                        subquery_duration.c.total_repertoire_duration +
                        (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
                        (subquery_entries.c.number_of_entries * FestivalClass.move_time)
                    ))
                elif order == 'desc':
                    stmt = stmt.order_by(desc(
                        subquery_duration.c.total_repertoire_duration +
                        (subquery_entries.c.number_of_entries * FestivalClass.adjudication_time) +
                        (subquery_entries.c.number_of_entries * FestivalClass.move_time)
                    ))
            else:
                if order == 'asc':
                    stmt = stmt.order_by(asc(getattr(FestivalClass, column)))
                elif order == 'desc':
                    stmt = stmt.order_by(desc(getattr(FestivalClass, column)))


    stmt = stmt.limit(per_page).offset((page - 1) * per_page)
```

The execution and rending of the template is as below. Now, the *_classes* object is a list of SQLAlchemy Row objects and the fields in each row can be accessed by the column name. So, I can pass this list directly to the template, without calling the *get_class_list* function.

```
    _classes = db.session.execute(stmt).all()

    return flask.render_template(
        'admin/class_report.html', 
        classes=_classes, 
        form=form,
        page=page,
        per_page=per_page,
        )
```

#### mfo/admin/templates/admin/partials/class_table.html

The template needs some changes to read each field correctly:

```
<!-- mfo/admin/templates/admin/partials/class_table.html -->

<table class="table" id="class-table">
    <thead>
      ....
    </thead>
    <tbody>
        {% for _class in classes %}
        <tr>
            <td><a href="{{ url_for('admin.class_info_get', id=_class.id) }}">{{ _class.number_suffix }}</a></td>
            <td>{{ _class.name }}</td>
            <td>{{ _class.discipline }}</td>
            <td>{{ _class.class_type }}</td>
            <td class="text-end">{{ _class.number_of_entries }}</td>
            <td class="text-end">${{ '%.2f' | format(_class.total_fees) }}</td>
            <td class="text-end">{{ format_time(_class.total_time, show_seconds=False) }}</td>
        </tr>
        
        {% endfor %}
    </tbody>
</table>
```

## Query with relationships

The query, with all the [subqueries](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#subqueries-and-ctes), seems very complex. It's using joins instead of relationships. Maybe it will be simpler if I use relationships

It turns out I can use relationships for joins, so I don't have to specify what column to join on (and I could make this even more succinct if I add foreign keys to my models)



```
    stmt = (
        select(
            func.concat(FestivalClass.number, FestivalClass.suffix).label('number_suffix'),
            (FestivalClass.name).label('name'),
            FestivalClass.discipline.label('discipline'),
            FestivalClass.class_type.label('class_type'),
            (func.count(Entry.id)).label('number_of_entries'),
            (FestivalClass.fee * func.count(Entry.id)).label('total_fees'),
            func.sum(Repertoire.duration) +
                (FestivalClass.adjudication_time * func.count(Entry.id)) +
                (FestivalClass.move_time * func.count(Entry.id))
            ).label('total_time')
        )
        .join(FestivalClass.entries)
        .join(Entry.repertoire)
        .group_by(FestivalClass.id)
        .having(func.count(Entry.id) > 0)
    )

    if sort_by and sort_order:
        for column, order in zip(sort_by, sort_order):
            if column == 'number_of_entries':
                if order == 'asc':
                    stmt = stmt.order_by(asc('number_of_entries'))
                elif order == 'desc':
                    stmt = stmt.order_by(desc('number_of_entries'))
            elif column == 'total_fees':
                if order == 'asc':
                    stmt = stmt.order_by(asc('total_fees'))
                elif order == 'desc':
                    stmt = stmt.order_by(desc('total_fees'))
            elif column == 'total_time':
                if order == 'asc':
                    stmt = stmt.order_by(asc('total_time'))
                elif order == 'desc':
                    stmt = stmt.order_by(desc('total_time'))
            else:
                if order == 'asc':
                    stmt = stmt.order_by(asc(getattr(FestivalClass, column)))
                elif order == 'desc':
                    stmt = stmt.order_by(desc(getattr(FestivalClass, column)))


    stmt = stmt.limit(per_page).offset((page - 1) * per_page)

```

But this fails because SQLite and Postgress seem to count too many entries. It seems that every time I run func.count(Entry.id), the result is larger than the previous time it was run. 

The func.count(Entry.id) does not correctly calculate the number of entries for each class because it is not properly grouped by *Entry.class_id*. Just adding *Entry.class_id* to the *group_by* clause does not help.

The class_entries subquery calculates the count of entries once and provides this count to the main query, ensuring that the count is accurate and not affected by other aggregations in the main query.

So, while I tried to avoid using subqueries, I still need them.

I still did not need the second subquery to add up repertoire durations per entry because I only run that calculation once in my main query. 

To get the number of entries, the subquery is:

```
    class_entries = (
        select(
            Entry.class_id,
            func.count(Entry.id).label('number_of_entries')
        )
        .group_by(Entry.class_id)
    ).subquery()
```

Then, reference the *number_of_entries* column from the results as *class_entries.c.number_of_entries* wherever you needed the count of entries per class. Except, after the column is defined in the query. Then it can be referenced by its column name, *number_of_entries*

Note that I am not selecting the ORM object FestivalClass, but an instead selecting individual columns from FestivalClass and creating calculated columns based on other columns in FestivalClass. The execution statement will deliver results as a list of Row objects.

So, I don't use the *selectinload* method, anymore, because I am using *join* methods to join tables together based on their relationships.

```
    stmt = (
        select(
            FestivalClass.id.label('id'),
            func.concat(FestivalClass.number, FestivalClass.suffix).label('number_suffix'),
            FestivalClass.name.label('name'),
            FestivalClass.discipline.label('discipline'),
            FestivalClass.class_type.label('class_type'),
            class_entries.c.number_of_entries,
            (FestivalClass.fee * class_entries.c.number_of_entries).label('total_fees'),
            (func.sum(Repertoire.duration) +
                (FestivalClass.adjudication_time * class_entries.c.number_of_entries) +
                (FestivalClass.move_time * class_entries.c.number_of_entries)
            ).label('total_time')
        )
        .join(FestivalClass.entries)
        .join(Entry.repertoire)
        .join(class_entries, FestivalClass.id == class_entries.c.class_id)
        .group_by(
            FestivalClass.id,
            FestivalClass.number,
            FestivalClass.suffix,
            FestivalClass.name,
            FestivalClass.discipline,
            FestivalClass.class_type,
            FestivalClass.fee,
            class_entries.c.number_of_entries,
        )
        .having(func.count(Entry.id) > 0)
    )
```

Above, I also list in the *group_by* method every column that was not part of an aggregation function like *sum* or *count*, according to [the recommendations of the SQLAlchemy docs](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#aggregate-functions-with-group-by-having)

https://learnsql.com/blog/must-appear-in-group-by-clause/

And, I can make the sort code shorter because the column names in each Row object may be assumed to match the names passed in via the *sort_by* list:

```
    if sort_by and sort_order:
        for column, order in zip(sort_by, sort_order):
            if order == 'asc':
                stmt = stmt.order_by(asc(column))
            elif order == 'desc':
                stmt = stmt.order_by(desc(column))
```

Finally, the pagination method remains the same as before:

```
    stmt = stmt.limit(per_page).offset((page - 1) * per_page)
```

## Add "next" and "previous" buttons


To the *class_table.html* template add buttons that get the next page of results and field that requests the number of results per page.

First, I added a new field to the form in *mfo/admin/forms.py*:

#### mfo/admin/forms.py 

```
class ClassSortForm(FlaskForm):
    # ...

    page_choices = [
        ("10", "10"),
        ("20", "20"),
        ("50", "50"),
        ("100000", "All"),
    ]

    page_rows = SelectField('Displayed rows:', choices=page_choices, validators=[InputRequired()])
    # ...
```

#### mfo/admin/templates/admin/partials/sort_classes_form.html

Then, I updated the *sort_classes_form.html* template to display that new field in the page:

```
<!-- mfo/admin/templates/admin/partials/sort_classes_form.html -->

<div class="row d-flex justify-content-center pt-3 pb-4">
    <div col-md-6>
        <form method="post" action="{{ url_for('admin.classes_post') }}">
            ...
            <div class="row mb-3 align-items-center d-flex justify-content-center">
                <div class="col-md-3 text-end">
                    {{ form.page_rows.label(class="form-label") }}
                </div>
                <div class="col-md-2">
                    {{ form.page_rows(class="form-select") }}
                </div>
            </div>
            <div class="row align-items-center d-flex justify-content-center">
            ...
            </div>
        </form>
    </div>
</div>
```

#### mfo/admin/templates/admin/partials/class_table.html

Then, I made a major addition to the *class_table.html* template. I added a new nav section at the bottom, after the table. This took a fair bit of Bootstrap 5 investigation and most of it has been generated by GitHub Copilot

```
<!-- mfo/admin/templates/admin/partials/class_table.html -->

<table class="table" id="class-table">
   ...
</table>

<div class="d-flex justify-content-center align-items-center mt-4 mb-4">
    <nav>
        <ul class="pagination mb-0">
            <li class="page-item {% if page == 1 %}disabled{% endif %}">
                <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=page-1, per_page=per_page) }}">
                    <span>&laquo;</span>
                </a>
            </li>
            {% set total_pages = (total_classes // per_page) + 1 %}
            {% if total_pages > 1 %}
                {% if page > 3 %}
                    <li class="page-item">
                        <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=1, per_page=per_page) }}">1</a>
                    </li>
                    {% if page > 4 %}
                        <li class="page-item disabled"><span class="page-link">...</span></li>
                    {% endif %}
                {% endif %}
                {% for p in range([1, page-2]|max, [total_pages, page+2]|min + 1) %}
                    <li class="page-item {% if p == page %}active{% endif %}">
                        <a class="page-link" href="{{ url_for('admin.classes_get', sort_by=sort_by, sort_order=sort_order, page=p, per_page=per_page) }}">{{ p }}</a>
                    </li>
                {% endfor %}
                {% if page < total_pages - 2 %}
                    {% if page < total_pages - 3 %}
                        <li class="page-item disabled"><span class="page-link">...</span></li>
                    {% endif %}
                    <li class="page-item">
                        <a class="page-link" 
                        href="{{ url_for('admin.classes_get', 
                        sort_by=sort_by, sort_order=sort_order, 
                        page=total_pages, per_page=per_page) }}">
                            {{ total_pages }}
                        </a>
                    </li>
                {% endif %}
            {% endif %}
            <li class="page-item {% if page == total_pages %}disabled{% endif %}">
                <a class="page-link" 
                href="{{ url_for('admin.classes_get', 
                sort_by=sort_by, sort_order=sort_order, 
                page=page+1, per_page=per_page) }}">
                    <span>&raquo;</span>
                </a>
            </li>
        </ul>

    </nav>
</div>
```

#### mfo/admin/views.py

Finally, I added logic to the *mfo/admin/views.py* module to handle the *page* and *per_page* variables

```
    page = int(flask.request.args.get('page', 1))
    per_page = int(flask.request.args.get('per_page', 10))

    # ...
    
    form.page_rows.data = str(per_page) if per_page else '10'
    
    # ...
    
    total_classes = db.session.execute(
        select(func.count(FestivalClass.id))
        .where(FestivalClass.entries.any())
    ).scalar()

    return flask.render_template(
        'admin/class_report.html', 
        sort_by=sort_by,
        sort_order=sort_order,
        classes=_classes, 
        form=form,
        page=page,
        per_page=per_page,
        total_classes=total_classes,
        )
```

## Conclusion

Now, a user can enter the number of rows to display on a page and that will be displayed when the Sort button is clicked.

If the user navigates forward to more pages and then decides they want to change the number of rows per page, the display goes back to page 1. I don't feel like making complex functions to keep the user near where they were looking in the data if they change the page size.