### PR TITLE
91 add level to class report pages

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -2,34 +2,30 @@
 
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileRequired
+from flask import current_app
 from wtforms import ValidationError, StringField, SubmitField, HiddenField, IntegerField, DecimalField, SelectField, TextAreaField, PasswordField
 from wtforms.validators import StopValidation, InputRequired, Length, Optional, NumberRange
 
+from mfo.database.models import Discipline, PerformanceType, Level
+from mfo.database.base import db
+from sqlalchemy import select
 
-class_types = [
-        ('', 'None'),
-        ('Solo', 'Solo'),
-        ('Duet', 'Duet'),
-        ('Trio', 'Trio'),
-        ('Quartet', 'Quartet'),
-        ('Quintet', 'Quintet'),
-        ('Recital', 'Recital'),
-        ('Ensemble', 'Ensemble'),
-    ]
+def get_choices(table_class, column_name, none_option=False):
+    """
+    Get a list of choices for a select field from a database table column.
+    :param table_class: SQLAlchemy table class
+    :param column_name: Name of the column to get choices from
+    :param none_option: Include a None option at the beginning of the list
+    :return: List of choices
+    """
+    with current_app.app_context():
+        column = getattr(table_class, column_name)
+        results = db.session.execute(select(column)).scalars().all()
+        choices_list = [(result, result) for result in results]
+        if none_option:
+            choices_list.insert(0, ('', 'None'))
+        return choices_list
 
-disciplines = [
-        ('', 'None'),
-        ('Vocal', 'Vocal'),
-        ('Piano', 'Piano'),
-        ('Organ', 'Organ'),
-        ('Strings', 'Strings'),
-        ('Recorder', 'Recorder'),
-        ('Woodwinds', 'Woodwinds'),
-        ('Brass', 'Brass'),
-        ('Percussion', 'Percussion'),
-        ('Instrumental', 'Instrumental'),
-        ('Musical Theatre', 'Musical Theatre'),
-    ]
 def validate_decimal_places(form, field):
     if field.data is not None:
         str_value = str(field.data)
@@ -53,14 +49,18 @@ class ConfirmForm(FlaskForm):
     cancel = SubmitField('Cancel')
     
 class EditClassBasicInfoForm(FlaskForm):
+    def __init__(self, *args, **kwargs):
+        super(EditClassBasicInfoForm, self).__init__(*args, **kwargs)
+        self.discipline.choices = get_choices(Discipline, 'name', none_option=True)
+        self.class_type.choices = get_choices(PerformanceType, 'name')
+        self.level.choices = get_choices(Level, 'name', none_option=True)
+
     number = StringField('Number', validators=[InputRequired(), Length(max=10)])
     suffix = StringField('Suffix', validators=[Optional(), Length(max=5)])
-    class_type_choices = class_types
-    class_type = SelectField('Class Type', choices=class_type_choices, validators=[Optional()])
+    class_type = SelectField('Class Type', validators=[Optional()])
     name = StringField('Name', validators=[Optional(), Length(max=60)])
-    discipline_choices = disciplines
-    discipline = SelectField('Discipline', choices=discipline_choices, validators=[Optional()])
-    
+    discipline = SelectField('Discipline', validators=[Optional()])
+    level = SelectField('Level', validators=[Optional()])
     fee = DecimalField(
         'Fee', 
         validators=[
@@ -74,16 +74,21 @@ class EditClassBasicInfoForm(FlaskForm):
     move_mins = IntegerField('Move Minutes', validators=[InputRequired()])
     move_secs = IntegerField('Move Seconds', validators=[InputRequired()])
     submit = SubmitField('Update')
-    
+
+
 class EditRepertoireForm(FlaskForm):
+    def __init__(self, *args, **kwargs):
+        super(EditRepertoireForm, self).__init__(*args, **kwargs)
+        self.discipline.choices = get_choices(Discipline, 'name', none_option=True)
+        self.type.choices = get_choices(PerformanceType, 'name', none_option=True)
+        self.level.choices = get_choices(Level, 'name', none_option=True)
+
     id = HiddenField('ID')
     title = StringField('Title', validators=[InputRequired(), Length(max=60)])
     composer = StringField('Composer', validators=[InputRequired(), Length(max=60)])
-    discipline_choices = disciplines
-    discipline = SelectField('Discipline', choices=discipline_choices, validators=[Optional()])
-    type_choices = class_types
-    type = SelectField('Type', choices=type_choices, validators=[Optional()])
-    level = StringField('Level', validators=[Optional(), Length(max=60)])
+    discipline = SelectField('Discipline', validators=[Optional()])
+    type = SelectField('Type', validators=[Optional()])
+    level = SelectField('Level', validators=[Optional()])
     duration_mins = IntegerField('Minutes', validators=[InputRequired()])
     duration_secs = IntegerField('Seconds', validators=[InputRequired()])
     description = TextAreaField('Description', validators=[Optional()], render_kw={"rows": 5, "placeholder": "Enter description here..."})
@@ -95,32 +100,35 @@ class ConfirmFestivalDataDelete(FlaskForm):
     submit = SubmitField('Delete Data')
 
 
+
+# these name of each label must match the key in the _classes dictionary
+field_choices = [
+    ("none", ""),
+    ("number_suffix", "Class Number"),
+    ("name", "Name"),
+    ("discipline", "Discipline"),
+    ("class_type", "Type"),
+    ("level", "Level"),
+    ("number_of_entries", "Entries"),
+    ("total_fees", "Total fees"),
+    ("total_time", "Total time"),
+]
+
+# these name of each label must the strings in the admin_services.sort_list() function
+order_choices = [
+    ("asc", "Ascending"),
+    ("desc", "Descending"),
+]
+
+page_choices = [
+    ("10", "10"),
+    ("20", "20"),
+    ("50", "50"),
+    ("100000", "All"),
+]
+
+
 class ClassSortForm(FlaskForm):
-    # these name of each label must match the key in the _classes dictionary
-    field_choices = [
-        ("none", ""),
-        ("number_suffix", "Class Number"),
-        ("name", "Name"),
-        ("discipline", "Discipline"),
-        ("class_type", "Type"),
-        ("number_of_entries", "Entries"),
-        ("total_fees", "Total fees"),
-        ("total_time", "Total time"),
-    ]
-
-    # these name of each label must the strings in the admin_services.sort_list() function
-    order_choices = [
-        ("asc", "Ascending"),
-        ("desc", "Descending"),
-    ]
-
-    page_choices = [
-        ("10", "10"),
-        ("20", "20"),
-        ("50", "50"),
-        ("100000", "All"),
-    ]
-
     reset = SubmitField('Reset')
     submit = SubmitField('Sort')
     page_rows = SelectField('Displayed rows:', choices=page_choices, validators=[InputRequired()])
@@ -134,28 +142,6 @@ class ClassSortForm(FlaskForm):
 
 
 class RepertoireSortForm(FlaskForm):
-    field_choices = [
-        ("none", ""),
-        ("title", "Title"),
-        ("composer", "Composer"),
-        ("level", "Level"),
-        ("type", "Type"),
-        ("discipline", "Discipline"),
-        ("duration", "Duration"),
-        ("number_of_entries", "Entries"),
-    ]
-    order_choices = [
-        ("asc", "Ascending"),
-        ("desc", "Descending"),
-    ]
-
-    page_choices = [
-        ("10", "10"),
-        ("20", "20"),
-        ("50", "50"),
-        ("100000", "All"),
-    ]
-
     reset = SubmitField('Reset')
     submit = SubmitField('Sort')
     page_rows = SelectField('Displayed rows:', choices=page_choices, validators=[InputRequired()])

--- a/mfo/admin/templates/admin/class_edit_info.html
+++ b/mfo/admin/templates/admin/class_edit_info.html
@@ -53,6 +53,12 @@
                 </div>
                 <div class="col-lg-4 col-md-6 col-12 mt-2">
                     <div class="form-group d-flex align-items-center">
+                        <label for="level" class="me-2"><strong>Level:</strong></label>
+                        {{ form.level(class="form-control") }}
+                    </div>
+                </div>
+                <div class="col-lg-4 col-md-6 col-12 mt-2">
+                    <div class="form-group d-flex align-items-center">
                         <label for="fee" class="me-2"><strong>Fee:</strong></label>
                         {{ form.fee(class="form-control" + (" is-invalid" if form.fee.errors else "")) }}
                     </div>

--- a/mfo/admin/templates/admin/partials/class_info_card_body.html
+++ b/mfo/admin/templates/admin/partials/class_info_card_body.html
@@ -16,6 +16,9 @@
             <p><strong>Discipline:</strong> {{ _class.discipline }}</p>
         </div>
         <div class="col-xl-2 col-md-4 col-sm-6 col-12">
+            <p><strong>Level:</strong> {{ _class.level | capitalize }}</p>
+        </div>
+        <div class="col-xl-2 col-md-4 col-sm-6 col-12">
             <p><strong>Fee:</strong> ${{ _class.fee }}</p>
         </div>
         <div class="col-xl-2 col-md-4 col-sm-6 col-12 d-none d-sm-block d-md-none">

--- a/mfo/admin/templates/admin/partials/class_table.html
+++ b/mfo/admin/templates/admin/partials/class_table.html
@@ -7,6 +7,7 @@
             <th>Name</th>
             <th>Discipline</th>
             <th>Type</th>
+            <th>Level</th>
             <th class="text-end">Entries</th>
             <th class="text-end">Total Fees</th>
             <th class="text-end">Total Time</th>
@@ -18,6 +19,7 @@
             <td>{{ _class.name }}</td>
             <td>{{ _class.discipline }}</td>
             <td>{{ _class.class_type }}</td>
+            <td>{{ _class.level | capitalize }}</td>
             <td class="text-end">{{ _class.number_of_entries }}</td>
             <td class="text-end">${{ '%.2f' | format(_class.total_fees) }}</td>
             <td class="text-end">{{ format_time(_class.total_time, show_seconds=False) }}</td>

--- a/tests/qcmf_data.json
+++ b/tests/qcmf_data.json
@@ -223,7 +223,6 @@
         "Composition"
     ],
     "LEVELS": [
-        "None",
         "Pre-Junior",
         "Junior",
         "Intermediate",


### PR DESCRIPTION
Add level to class pages

Add level to class report columns and to class edit pages

## Current situation

The class *level* is passed to the class info and edit templates as part of a "class" object. So, I should just have to update the template and form.

But, it is not passed to the class report template. We need to add it in the view function and template, and add it as options in the form.

### Forms

Forms to look at are:

* EditClassBasicInfoForm()
* ClassSortForm()

### View functions

View functions to look at are:

* classes\_get()
* classes\_post()
* class\_info\_get()
* edit\_class\_info\_get()
* edit\_class\_info\_post()

### Templates

Templates to look at are:

* admin/class\_report.html
* admin/class\_info.html
* admin/class\_edit\_info.html

## Forms

I like to start with forms. In this case, the forms are in the module, *mfo/admin/forms.py*.

### Dynamic SelectField choices

First, I want to make the SelectField choices dynamic. I need to get the choices for Discipline and Type from the database. 

#### mfo/admin/forms.py

I added a new function *get_choices()* to *forms.py*. It will return a list of choices from a table column.

```
# ...
from flask import current_app
# ...

from mfo.database.models import Discipline, PerformanceType, Level
from mfo.database.base import db
from sqlalchemy import select

def get_choices(table_class, column_name, none_option=False):
    """
    Get a list of choices for a select field from a database table column.
    :param table_class: SQLAlchemy table class
    :param column_name: Name of the column to get choices from
    :param none_option: Include a None option at the beginning of the list
    :return: List of choices
    """
    with current_app.app_context():
        column = getattr(table_class, column_name)
        results = db.session.execute(select(column)).scalars().all()
        choices_list = [(result, result) for result in results]
        if none_option:
            choices_list.insert(0, ('', 'None'))
        return choices_list
# ...
```

Then, in the *EditClassBasicInfoForm()* form class, I removed the choices parameter from the *class_type* and *discipline* Selectfields. I then initialize the choices by calling the *get_choices()* function for the Discipline and PerformanceType tables. I also add a level field, using choices from the Level table.

```
class EditClassBasicInfoForm(FlaskForm):
    def __init__(self, *args, **kwargs):
        super(EditClassBasicInfoForm, self).__init__(*args, **kwargs)
        self.discipline.choices = get_choices(Discipline, 'name', none_option=True)
        self.class_type.choices = get_choices(PerformanceType, 'name')
        self.level.choices = get_choices(Level, 'name', none_option=True)

    number = StringField('Number', validators=[InputRequired(), Length(max=10)])
    suffix = StringField('Suffix', validators=[Optional(), Length(max=5)])
    class_type = SelectField('Class Type', validators=[Optional()])
    name = StringField('Name', validators=[Optional(), Length(max=60)])
    discipline = SelectField('Discipline', validators=[Optional()])
    level = SelectField('Level', validators=[Optional()])
    # ...
```

---

**Learning Point:** The *EditClassBasicInfoForm()* class is the "child" of the *FlaskForm()* class. Both the child and parent classes have their own *\_\_init\_\_()* methods. When I create an instance of *EditClassBasicInfoForm()*, its *\_\_init\_\_()* method is automatically called.

In the *EditClassBasicInfoForm* class's *\_\_init\_\_()* method, the first line's *super().\_\_init\_\_()* statement ensures that the parent class, *FlaskForm*, sets up the form fields correctly, as it normally would. For example, the *discipline* field, which is an instance of *SelectField*, gets created at this point. Without this call to *super()*, the parent class's setup logic would not run, and the form would be incomplete.

After the parent class’s initialization is complete, the overridden *\_\_init\_\_* method adds custom behavior. Specifically, it assigns the *.choices* attribute to the *SelectField* fields (*discipline*, *class_type*, and *level*) by calling the *get_choices* function. This makes the dropdown options in the form dynamic, as they can be populated from external sources like a database.

The *super()* call allows you to extend the behavior of the parent class without replacing it entirely. You can think of it as calling the "default" setup logic of the parent class first, and then adding your own enhancements afterward. The *\_\_init\_\_()* method dynamically assigns options to dropdown fields, like *SelectField*, based on the *get_choices()* function. This means that when the form is displayed to the user, the dropdown menus will have options tailored to the data in your application.

---

I did the same for the *EditRepertoireForm* form class:

```
class EditRepertoireForm(FlaskForm):
    def __init__(self, *args, **kwargs):
        super(EditRepertoireForm, self).__init__(*args, **kwargs)
        self.discipline.choices = get_choices(Discipline, 'name', none_option=True)
        self.type.choices = get_choices(PerformanceType, 'name', none_option=True)
        self.level.choices = get_choices(Level, 'name', none_option=True)

    id = HiddenField('ID')
    title = StringField('Title', validators=[InputRequired(), Length(max=60)])
    composer = StringField('Composer', validators=[InputRequired(), Length(max=60)])
    discipline = SelectField('Discipline', validators=[Optional()])
    type = SelectField('Type', validators=[Optional()])
    level = SelectField('Level', validators=[Optional()])
    duration_mins = IntegerField('Minutes', validators=[InputRequired()])
    duration_secs = IntegerField('Seconds', validators=[InputRequired()])
    description = TextAreaField('Description', validators=[Optional()], render_kw={"rows": 5, "placeholder": "Enter description here..."})
    submit = SubmitField('Update')
```

Finally, I add *level* as a choice to the *field_choices* list in the *forms.py* file:

```
field_choices = [
    ("none", ""),
    ("number_suffix", "Class Number"),
    ("name", "Name"),
    ("discipline", "Discipline"),
    ("class_type", "Type"),
    ("level", "Level"),
    ("number_of_entries", "Entries"),
    ("total_fees", "Total fees"),
    ("total_time", "Total time"),
]
```

The *field_choices* list is used to define the sort criteria in the *ClassSortForm()* and *RepertoireSortForm()* form classes. Changing the *field_choices* list is all that's required to add sort criteria, as long as the table being sorted has the column names matching the sort criteria.

## Update the templates

I need to add the *level* column to the classes report and to the class information page.

#### mfo/admin/templates/admin/partials/class_table.html

I just added a header for the level column and data for the column. The *level* column is already in the *classes* database result passed into the template.
```
<!-- mfo/admin/templates/admin/partials/class_table.html -->
...
    <thead>
        <tr>
            ...
            <th>Level</th>
            ...
    </thead>
    <tbody>
        {% for _class in classes %}
        <tr>
            ...
            <td>{{ _class.level | capitalize }}</td>
            ...
        </tr>
```

I used the *capitalize* Jinja filter to capitalize the level names. I needed to do this because I am not consistent with how I capitalize labels for default data in the database. The *Discipline* and *PerformanceType* tables have capitalized data and the *Level* table has all lowercase data in the name fields.

I should probably be consistent one way or the other. This is a problem for the far future, I think.


#### mfo/admin/templates/admin/partials/class_info_card_body.html

I added the *level* data, with the *capitalize* filter, to the class info partial template, after the *discipline* data:

```
    <div class="col-xl-2 col-md-4 col-sm-6 col-12">
        <p><strong>Level:</strong> {{ _class.level | capitalize }}</p>
    </div>
```

I still need to do some work with the Bootstrap column sizing so thing line up correctly in different viewport sizes. But, for now, this is good enough.

#### mfo/admin/templates/admin/class_edit_info.html

I added the *level* form field to the class edit template. As with the class info template, above, I still need to revisit the Bootstrap column breakpoints for all fields in the form so the form looks good in all screen sizes.

```
    <div class="col-lg-4 col-md-6 col-12 mt-2">
        <div class="form-group d-flex align-items-center">
            <label for="level" class="me-2"><strong>Level:</strong></label>
            {{ form.level(class="form-control") }}
        </div>
    </div>
```

For now, though, it looks good enough.

## Conclusion

I was able to add *levels* to the class report, class info, and class_edit pages. I updated the forms and the templates but did not need to change any view functions. This is because I collect the full rows from the database in the view functions so the *level* was already in the data passed to the templates.