### PR TITLE
103 add entries to profile reports

### DIFF
--- a/mfo/admin/forms.py
+++ b/mfo/admin/forms.py
@@ -182,6 +182,7 @@ class ParticipantSortForm(ReportSortForm):
             ("address", "Address"),
             ("city", "City"),
             ("school", "School"),
+            ("number_of_entries", "Entries"),
         ]
         
         if role == "Group":

--- a/mfo/admin/templates/admin/profile_report.html
+++ b/mfo/admin/templates/admin/profile_report.html
@@ -51,7 +51,7 @@
                 <td class="text-wrap">
                 {% if role == 'Participant' or role == 'Group' %}
                     {% if profile.attends_school %}
-                        {{ profile.attends_school.name }}
+                        {{ profile.attends_school }}
                     {% else %}
                         None
                     {% endif %}
@@ -59,7 +59,7 @@
                     {{ profile.postal_code }}
                 {% endif %}
                 </td>
-                <td class="text-nowrap">{{ profile.number_of_entries }}</td>
+                <td class="text-nowrap">{{ profile.number_of_entries or 0}}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/mfo/admin/templates/admin/profile_report.html
+++ b/mfo/admin/templates/admin/profile_report.html
@@ -59,7 +59,7 @@
                     {{ profile.postal_code }}
                 {% endif %}
                 </td>
-                <td class="text-nowrap">{{ profile.number_of_entries or 0}}</td>
+                <td class="text-nowrap text-end pe-4">{{ profile.number_of_entries or 0}}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/mfo/admin/templates/admin/profile_report.html
+++ b/mfo/admin/templates/admin/profile_report.html
@@ -33,6 +33,7 @@
                 {% else %}
                 <th>Postal Code</th>
                 {% endif %}
+                <th>Entries</th>
             </tr>
         </thead>
         <tbody>
@@ -58,6 +59,7 @@
                     {{ profile.postal_code }}
                 {% endif %}
                 </td>
+                <td class="text-nowrap">{{ profile.number_of_entries }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/mfo/admin/views.py
+++ b/mfo/admin/views.py
@@ -216,14 +216,15 @@ def profile_report_get():
     
     # Define aliases for Profile
     student_alias = aliased(Profile)
+    teacher_alias = aliased(Profile)
     entry_alias = aliased(Entry)
 
     # Define subqueries for num_entries
     if role == 'Teacher':
         entries_subquery = (
-            select(Profile.id, func.count(Entry.id).label('number_of_entries'))
-            .join(Profile.teaches_entries)
-            .group_by(Profile.id)
+            select(teacher_alias.id, func.count(student_alias.id).label('number_of_entries'))
+            .join(teacher_alias.students)
+            .group_by(student_alias.id)
             .subquery()
         )
         


### PR DESCRIPTION
## Look at models

Profile has a many-to-many relationships with the Entry table. The relationships relevant to this issue are:

* accompanies\_entries
* participates\_in\_entries
* students

In the teachers report, the number of entries associated with each teacher is derived by following the *students* many-to-many relationship to get a list of each of that teacher's students and then follow the *participates_in_entries* many-to-many relationship to get the entries for each of the teacher's students.

In the accompanists report, the number of entries is derived by counting the items in the list returned by querying the *accompanies_entries* relationship.

In the participants report, the number of entries is derived by counting the items in the *participates\_in\_entries* relationship.

## Get entries data in view function

In the *profile_report_get()* view function in the *mfo/admin/views.py* module, look at the value in the *role* variable and run a different set of steps for each role. The output should be a scalar value representing the number of entries counted.

Then, add the *entries_count* variable to the template context in the return statement.

#### mfo/admin/views.py

First, I created different subqueries for each role.

I quickly discovered that SQL needed help handling 

So I created aliased for the Profile table so SQLAlchemy can which "view" of teh profile table to use at the appropriate time.

```
    # Define aliases for Profile
    student_profile = aliased(Profile)
    teacher_profile = aliased(Profile)
```

Then, I created subqueries to count the number of entries. This is done differently for each role.

For the teacher role, I first create a subquery that returns a list of student IDs for each teacher. To do this, I had to join the Profile table with itself, which is why I had to create the aliases above, so SQLAlchemy can treat each instance of the Profile table as a different table. And I grouped the results by both the *teacher_profile.id* and *student_profile.id* to ensure that each teacher-student pair is uniquely identified.

```
    if role == 'Teacher':
        students_subquery = (
            select(
                teacher_profile.id.label("teacher_id"), 
                student_profile.id.label("student_id")
            ).outerjoin(
                student_profile, 
                teacher_profile.students
            ).group_by(
                teacher_profile.id, 
                student_profile.id
            )
        ).subquery()
```

Next, I used the results of the *students_subquery* in another subquery called *entries_subquery*.

To get the entries to count, I performed an outer join between the *students_subquery* results and the *student_profile* (*Profile*) table to include all students for each teacher. Then, I performed another outer join between the *student_profile* (*Profile*) table and the *Entry* table to include all entries for each student. Finally, I grouped the results by *teacher_id* so the count function can calculate the total number of entries for each teacher.

```
        entries_subquery = (
            select(
                students_subquery.c.teacher_id.label("profile_id"),
                func.count(Entry.id).label('number_of_entries')
            ).outerjoin(
                student_profile, 
                student_profile.id == students_subquery.c.student_id
            ).outerjoin(
                Entry, 
                student_profile.participates_in_entries
            ).group_by(
                students_subquery.c.teacher_id
            )
        ).subquery()
```

For the *Accompanist* role, I had to join the *Profile* table with the Entry table and count the entries per accompanist by following the *accompanies_entries* relationship. I don't need to use aliases in this case because I am not joining a table with itself.

```
    elif role == 'Accompanist':
        entries_subquery = (
            select(
                Profile.id.label("profile_id"), 
                func.count(Entry.id).label('number_of_entries')
            ).outerjoin(
                Entry, 
                Profile.accompanies_entries
            ).group_by(
                Profile.id
            )
        ).subquery()
```

For the *Participant* and *Group* roles, I did the same as the *Accompanist* role, except I used the *Profile.participates_in_entries* relationship.

```
    elif role == 'Participant' or role == 'Group':
        entries_subquery = (
            select(
                Profile.id.label("profile_id"),
                func.count(Entry.id).label("number_of_entries")
            ).outerjoin(
                Entry, 
                Profile.participates_in_entries
            ).group_by(
                Profile.id
            )
        ).subquery()
```

Next, I changed the main *select* statement because I am no longer using only results from the *Profile* table; I am now also including results from the *School* table and from the *subqueries*. So, I will select specific columns.

For some reason, I had to explicitly label the *Profile.name* column or SQLAlchemy would mix it up with the School name column when sorting.

```
    stmt = (
        select(
            Profile.name.label("name"),
            Profile.group_name,
            Profile.email,
            Profile.phone,
            Profile.address,
            Profile.city,
            Profile.province,
            Profile.postal_code,
            School.name.label("attends_school"),
            entries_subquery.c.number_of_entries
        ).outerjoin(
            entries_subquery,
            Profile.id == entries_subquery.c.profile_id
        ).outerjoin(School, Profile.attends_school
        ).filter(Profile.roles.any(name=role))
    )
```

I added a filter to use if the *hide_zero_entries* checkbox was selected:

```
    if hide_zero_entries:
        stmt = stmt.filter(func.coalesce(entries_subquery.c.number_of_entries, 0) > 0)
```

Finally, I changed the *execute* statement so I no longer use the *scalars()* method. This is because I am no longer expecting results from one single table so, instead of a list of *Profile* objects, I will have a list of named tuples.

```
    profiles = db.session.execute(stmt).all()
```

## Update the template

Because I am no longer using the a list of *Profile* objects to pass data to the profile report template, I changed the variable name for teh school name so it no longer tries to get the relationship *profile.attends_school.name* but now accesses the item in the named tuple, named *profile.attends_school*

#### admin/templates/admin/profile_report.html

```
...
    <td class="text-wrap">
    {% if role == 'Participant' or role == 'Group' %}
        {% if profile.attends_school %}
            {{ profile.attends_school }}
        {% else %}
            None
        {% endif %}
    {% else %}
        {{ profile.postal_code }}
    {% endif %}
            </td>
...
```

## Update the forms

Now that I have a new column named *Entries* in the profile reports, i want to sort on it. This is easily arranged by updating the choices in the form and ensuring that the choices value matches the column name in the database results.

#### mfo/admin/forms.py

I just added *Entries* to the *field_choices* list in the *ParticipantSortForm* form.

```
class ParticipantSortForm(ReportSortForm):
    def __init__(self, role):
        super(ParticipantSortForm, self).__init__()

        field_choices = [
            ("none", ""),
            ("name", "Name"),
            ("email", "E-mail"),
            ("phone", "Phone"),
            ("address", "Address"),
            ("city", "City"),
            ("school", "School"),
            ("number_of_entries", "Entries"),
        ]
    ...
```
