### PR TITLE
Changed the range of numbers for the Vocal discipline in the syllabus…

### DIFF
--- a/mfo/admin/services/admin_services.py
+++ b/mfo/admin/services/admin_services.py
@@ -11,7 +11,7 @@ level_map = pd.read_json(TEST_LEVEL_MAP, orient='records')
 
 def infer_discipline(class_number):
     """ Infer discipline based on class number """
-    if 200 <= class_number <= 706:
+    if 0 <= class_number <= 999:
         return "Vocal" # Ensemble
     elif 1000 <= class_number <= 1999:
         return "Vocal"


### PR DESCRIPTION
Previously, I hard-coded the allowable class numbers for Vocal discipline to a range from 200 to 706. New version of Syllabus has numbers outside this range.

Keep things flexible and increase class number range for Vocal to 0 to 999